### PR TITLE
Vst plugin updates

### DIFF
--- a/LiveSPICEVst/EditorView.xaml
+++ b/LiveSPICEVst/EditorView.xaml
@@ -20,7 +20,7 @@
                     <TextBlock Margin="5,0,5,0">View</TextBlock>
                 </Button>
                 <Button x:Name="LoadCircuitButton" Click="LoadCircuitButton_Click" MaxWidth="200">
-                    <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding Path=CircuitName, ElementName=MyEditorView}" />
+                    <TextBlock TextTrimming="CharacterEllipsis">Load Schematic</TextBlock>
                 </Button>
             </DockPanel>
             <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5" UseLayoutRounding="True">
@@ -31,14 +31,14 @@
                     </Style>
                 </StackPanel.Resources>
                 <TextBlock>Oversample:</TextBlock>
-                <ComboBox x:Name="OversampleComboBox" SelectedIndex="1" SelectionChanged="OversampleComboBox_SelectionChanged">
+                <ComboBox x:Name="OversampleComboBox" SelectionChanged="OversampleComboBox_SelectionChanged">
                     <ComboBoxItem>1</ComboBoxItem>
                     <ComboBoxItem>2</ComboBoxItem>
                     <ComboBoxItem>4</ComboBoxItem>
                     <ComboBoxItem>8</ComboBoxItem>
                 </ComboBox>
                 <TextBlock>Iterations:</TextBlock>
-                <ComboBox x:Name="IterationsComboBox" SelectedIndex="3" SelectionChanged="IterationsComboBox_SelectionChanged">
+                <ComboBox x:Name="IterationsComboBox" SelectionChanged="IterationsComboBox_SelectionChanged">
                     <ComboBoxItem>1</ComboBoxItem>
                     <ComboBoxItem>2</ComboBoxItem>
                     <ComboBoxItem>4</ComboBoxItem>

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -2,6 +2,7 @@
 using Microsoft.Win32;
 using SharpSoundDevice;
 using System;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -15,6 +16,7 @@ namespace LiveSPICEVst
         public LiveSPICEPlugin Plugin { get; private set; }
 
         SchematicWindow schematicWindow = null;
+        string schematicPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "LiveSPICE"), "Examples");
 
         public EditorView(LiveSPICEPlugin plugin)
         {
@@ -55,11 +57,14 @@ namespace LiveSPICEVst
         {
             OpenFileDialog dialog = new OpenFileDialog();
 
+            dialog.InitialDirectory = schematicPath;
             dialog.Filter = "Circuit Schemas (*.schx)|*.schx";
 
             if (dialog.ShowDialog() == true)
             {
                 string path = dialog.FileName;
+
+                schematicPath = Path.GetDirectoryName(path);
 
                 Plugin.LoadSchematic(path);
             }

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -37,6 +37,26 @@ namespace LiveSPICEVst
             (LoadCircuitButton.Content as TextBlock).Text = (Plugin.SimulationProcessor.Schematic != null) ? Plugin.SimulationProcessor.SchematicName : "Load Schematic";
 
             schematicWindow = null;
+
+            for (int i = 0; i < OversampleComboBox.Items.Count; i++)
+            {
+                if (int.Parse((OversampleComboBox.Items[i] as ComboBoxItem).Content as string) == Plugin.SimulationProcessor.Oversample)
+                {
+                    OversampleComboBox.SelectedIndex = i;
+
+                    break;
+                }
+            }
+
+            for (int i = 0; i < IterationsComboBox.Items.Count; i++)
+            {
+                if (int.Parse((IterationsComboBox.Items[i] as ComboBoxItem).Content as string) == Plugin.SimulationProcessor.Iterations)
+                {
+                    IterationsComboBox.SelectedIndex = i;
+
+                    break;
+                }
+            }
         }
 
         private void OversampleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -67,6 +87,8 @@ namespace LiveSPICEVst
                 schematicPath = Path.GetDirectoryName(path);
 
                 Plugin.LoadSchematic(path);
+
+                UpdateSchematic();
             }
         }
 

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -14,19 +14,27 @@ namespace LiveSPICEVst
     {
         public LiveSPICEPlugin Plugin { get; private set; }
 
-        public string CircuitName { get; private set; }
-
-        Schematic schematic = null;
         SchematicWindow schematicWindow = null;
 
         public EditorView(LiveSPICEPlugin plugin)
         {
-            CircuitName = "Load Circuit";
-
             this.Plugin = plugin;
             this.DataContext = Plugin;
 
+            Plugin.EditorView = this;
+
             InitializeComponent();
+
+            UpdateSchematic();
+        }
+
+        public void UpdateSchematic()
+        {
+            OverlaySchematic.DataContext = Plugin.SimulationProcessor.Schematic;
+
+            (LoadCircuitButton.Content as TextBlock).Text = (Plugin.SimulationProcessor.Schematic != null) ? Plugin.SimulationProcessor.SchematicName : "Load Schematic";
+
+            schematicWindow = null;
         }
 
         private void OversampleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -53,22 +61,7 @@ namespace LiveSPICEVst
             {
                 string path = dialog.FileName;
 
-                try
-                {
-                    schematic = Schematic.Load(path);
-
-                    OverlaySchematic.DataContext = schematic;
-
-                    Plugin.SimulationProcessor.SetCircuit(schematic.Build());
-
-                    CircuitName = System.IO.Path.GetFileNameWithoutExtension(path);
-                    (LoadCircuitButton.Content as TextBlock).Text = CircuitName;
-
-                    schematicWindow = null;
-                }
-                catch
-                {
-                }
+                Plugin.LoadSchematic(path);
             }
         }
 
@@ -80,15 +73,15 @@ namespace LiveSPICEVst
 
         private void ShowCircuitButton_Click(object sender, RoutedEventArgs e)
         {
-            if (schematic != null)
+            if (Plugin.SimulationProcessor.Schematic != null)
             {
                 if (schematicWindow == null)
                 {
                     schematicWindow = new SchematicWindow()
                     {
                         Owner = Window.GetWindow(this),
-                        DataContext = schematic,
-                        Title = CircuitName
+                        DataContext = Plugin.SimulationProcessor.Schematic,
+                        Title = Plugin.SimulationProcessor.SchematicName
                     };
                 }
                 

--- a/LiveSPICEVst/LiveSPICEVst.csproj
+++ b/LiveSPICEVst/LiveSPICEVst.csproj
@@ -57,6 +57,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VstProgramParameters.cs" />
     <Compile Include="SchematicWindow.xaml.cs">
       <DependentUpon>SchematicWindow.xaml</DependentUpon>
     </Compile>

--- a/LiveSPICEVst/SimulationProcessor.cs
+++ b/LiveSPICEVst/SimulationProcessor.cs
@@ -1,8 +1,9 @@
-﻿using Circuit;
-using ComputerAlgebra;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Circuit;
+using ComputerAlgebra;
 
 namespace LiveSPICEVst
 {
@@ -91,6 +92,10 @@ namespace LiveSPICEVst
     {
         public ObservableCollection<ComponentWrapper> InteractiveComponents { get; private set; }
 
+        public Schematic Schematic { get; private set; }
+        public string SchematicPath { get; private set; }
+        public string SchematicName { get; private set; }
+
         public double SampleRate
         {
             get { return sampleRate; }
@@ -136,7 +141,34 @@ namespace LiveSPICEVst
             InteractiveComponents = new ObservableCollection<ComponentWrapper>();
         }
 
-        public void SetCircuit(Circuit.Circuit circuit)
+        public void LoadSchematic(string path)
+        {
+            //try
+            //{
+            Schematic newSchematic = Circuit.Schematic.Load(path);
+
+                Circuit.Circuit circuit = newSchematic.Build();
+
+                SetCircuit(circuit);
+
+                Schematic = newSchematic;
+
+                //OverlaySchematic.DataContext = schematic;
+
+                SchematicName = System.IO.Path.GetFileNameWithoutExtension(path);
+                //(LoadCircuitButton.Content as TextBlock).Text = SchematicName;
+
+                //schematicWindow = null;
+
+                SchematicPath = path;
+            //}
+            //catch (Exception ex)
+            //{
+            //    MessageBox.Show(String.Format("Error loading circuit from: {0}\n\n{1}", path, ex.Message), "Circuit Load Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            //}
+        }
+
+        void SetCircuit(Circuit.Circuit circuit)
         {
             this.circuit = circuit;
 
@@ -181,6 +213,18 @@ namespace LiveSPICEVst
             needRebuild = true;
         }
 
+        public void ClearCircuit()
+        {
+            circuit = null;
+
+            InteractiveComponents.Clear();
+        }
+
+        /// <summary>
+        /// Run the cicuite simulation on a buffer of audio samples
+        /// </summary>
+        /// <param name="audioInput">Array of input samples</param>
+        /// <param name="audioOutput">Array of output samples</param>
         public void RunSimulation(double[] audioInput, double[] audioOutput)
         {
             if (circuit == null)

--- a/LiveSPICEVst/SimulationProcessor.cs
+++ b/LiveSPICEVst/SimulationProcessor.cs
@@ -143,29 +143,17 @@ namespace LiveSPICEVst
 
         public void LoadSchematic(string path)
         {
-            //try
-            //{
             Schematic newSchematic = Circuit.Schematic.Load(path);
 
-                Circuit.Circuit circuit = newSchematic.Build();
+            Circuit.Circuit circuit = newSchematic.Build();
 
-                SetCircuit(circuit);
+            SetCircuit(circuit);
 
-                Schematic = newSchematic;
+            Schematic = newSchematic;
 
-                //OverlaySchematic.DataContext = schematic;
+            SchematicName = System.IO.Path.GetFileNameWithoutExtension(path);
 
-                SchematicName = System.IO.Path.GetFileNameWithoutExtension(path);
-                //(LoadCircuitButton.Content as TextBlock).Text = SchematicName;
-
-                //schematicWindow = null;
-
-                SchematicPath = path;
-            //}
-            //catch (Exception ex)
-            //{
-            //    MessageBox.Show(String.Format("Error loading circuit from: {0}\n\n{1}", path, ex.Message), "Circuit Load Error", MessageBoxButton.OK, MessageBoxImage.Error);
-            //}
+            SchematicPath = path;
         }
 
         void SetCircuit(Circuit.Circuit circuit)
@@ -211,13 +199,6 @@ namespace LiveSPICEVst
             }
 
             needRebuild = true;
-        }
-
-        public void ClearCircuit()
-        {
-            circuit = null;
-
-            InteractiveComponents.Clear();
         }
 
         /// <summary>

--- a/LiveSPICEVst/VstProgramParameters.cs
+++ b/LiveSPICEVst/VstProgramParameters.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LiveSPICEVst
+{
+    /// <summary>
+    /// Class to hold VST parameters to allow the host to restore the plugin state
+    /// </summary>
+    public class VstProgramParameters
+    {
+        public string SchematicPath { get; set; }
+        public int OverSample { get; set; }
+        public int Iterations { get; set; }
+
+        public VstProgramParameters()
+        {
+            OverSample = 2;
+            Iterations = 8;
+        }
+    }
+}


### PR DESCRIPTION
I did some refactoring of the interface between the plugin code, the UI, and the SimulationProcessor class. I think it is cleaner now.

I also added in some error handling, and support for VST program load/save. It saves your selected schematic, as well as your settings for oversample/iterations. It does not current save pot/button values.

Oh, and I now have it defaulting to load schematics from MyDocuments.