### PR TITLE
Remove allocations and UI updates from the audio processing thread

### DIFF
--- a/LiveSPICE/Controls/Scope/SignalCollection.cs
+++ b/LiveSPICE/Controls/Scope/SignalCollection.cs
@@ -47,14 +47,6 @@ namespace LiveSPICE
             remove { itemRemoved.Remove(value); }
         }
 
-        private List<EventHandler<TickEventArgs>> tick = new List<EventHandler<TickEventArgs>>();
-        protected void OnTick(long Clock) { TickEventArgs e = new TickEventArgs(Clock); foreach (EventHandler<TickEventArgs> i in tick) i(this, e); }
-        public event EventHandler<TickEventArgs> ClockTicked
-        {
-            add { tick.Add(value); }
-            remove { tick.Remove(value); }
-        }
-
         private long clock = 0;
         public long Clock { get { return clock; } }
 
@@ -75,8 +67,6 @@ namespace LiveSPICE
                 else
                     i.Truncate(truncate);
             });
-
-            OnTick(clock);
 
             clock += SampleCount;
         }

--- a/LiveSPICE/Controls/Scope/SignalDisplay.cs
+++ b/LiveSPICE/Controls/Scope/SignalDisplay.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -15,19 +16,25 @@ namespace LiveSPICE
             get { return signals; }
             set
             {
-                if (signals != null)
-                    signals.ClockTicked -= Invalidate;
                 signals = value;
-                if (signals != null)
-                    signals.ClockTicked += Invalidate;
                 InvalidateVisual();
                 NotifyChanged("Signals");
             }
         }
 
-        void Invalidate(object sender, EventArgs e)
+        private System.Timers.Timer refreshTimer;
+
+        public SignalDisplay()
         {
-            Dispatcher.InvokeAsync(() => InvalidateVisual(), System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+            refreshTimer = new System.Timers.Timer()
+            {
+                Interval = 16,
+                AutoReset = true,
+                Enabled = true,
+            };
+            refreshTimer.Elapsed +=
+                (o, e) => Dispatcher.InvokeAsync(() => InvalidateVisual(), System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+            refreshTimer.Start();
         }
 
         private Signal selected;
@@ -42,8 +49,7 @@ namespace LiveSPICE
         // INotifyPropertyChanged interface.
         protected void NotifyChanged(string p)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(p));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
         }
         public event PropertyChangedEventHandler PropertyChanged;
     }

--- a/LiveSPICE/Controls/Scope/SignalDisplay.cs
+++ b/LiveSPICE/Controls/Scope/SignalDisplay.cs
@@ -28,7 +28,7 @@ namespace LiveSPICE
         {
             refreshTimer = new System.Timers.Timer()
             {
-                Interval = 16,
+                Interval = 16,  // 60 Hz
                 AutoReset = true,
                 Enabled = true,
             };

--- a/LiveSPICE/Controls/Simulation/Channel.cs
+++ b/LiveSPICE/Controls/Simulation/Channel.cs
@@ -19,11 +19,25 @@ namespace LiveSPICE
         private Brush signalStatus = Brushes.Transparent;
         public Brush SignalStatus { get { return signalStatus; } set { signalStatus = value; NotifyChanged("SignalStatus"); } }
 
+        private double signalLevel = 0;
+        public double SignalLevel { get { return signalLevel; } }
+        /// <summary>
+        /// Update the signal level of this channel.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="time"></param>
+        public void SampleSignalLevel(double level, double time)
+        {
+            double a = Frequency.DecayRate(time, 0.25);
+            signalLevel = Math.Max(level, level * a + signalLevel * (1 - a));
+        }
+
+        public void ResetSignalLevel() { signalLevel = 0; }
+
         // INotifyPropertyChanged.
         protected void NotifyChanged(string p)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(p));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
         }
         public event PropertyChangedEventHandler PropertyChanged;
     }

--- a/LiveSPICE/LiveSimulation.xaml.cs
+++ b/LiveSPICE/LiveSimulation.xaml.cs
@@ -75,6 +75,7 @@ namespace LiveSPICE
 
         private Dictionary<ComputerAlgebra.Expression, Channel> inputs = new Dictionary<ComputerAlgebra.Expression, Channel>();
 
+        // A timer for continuously refreshing controls.
         protected System.Timers.Timer timer;
 
         public LiveSimulation(Circuit.Schematic Simulate, Audio.Device Device, Audio.Channel[] Inputs, Audio.Channel[] Outputs)

--- a/LiveSPICE/LiveSimulation.xaml.cs
+++ b/LiveSPICE/LiveSimulation.xaml.cs
@@ -421,19 +421,6 @@ namespace LiveSPICE
             }
         }
 
-        private static double AmplifySignal(Audio.SampleBuffer Samples, double Gain)
-        {
-            double peak = 0.0;
-            for (int i = 0; i < Samples.Count; ++i)
-            {
-                double v = Samples[i];
-                v *= Gain;
-                peak = Math.Max(peak, Math.Abs(v));
-                Samples[i] = v;
-            }
-            return peak;
-        }
-
         private void OnElementAdded(object sender, Circuit.ElementEventArgs e)
         {
             if (e.Element is Circuit.Symbol && ((Circuit.Symbol)e.Element).Component is Probe)
@@ -538,6 +525,7 @@ namespace LiveSPICE
                 default: return ElementControl.MapToPen(Color);
             }
         }
+
         private static Brush MapSignalToBrush(double Peak)
         {
             if (Peak < 1e-3) return Brushes.Transparent;

--- a/LiveSPICE/Utils/Frequency.cs
+++ b/LiveSPICE/Utils/Frequency.cs
@@ -136,5 +136,15 @@ namespace LiveSPICE
             }
             return data;
         }
+
+        /// <summary>
+        /// Get the parameter for a first-order IIR filter.
+        /// </summary>
+        /// <param name="timestep">The time between steps.</param>
+        /// <param name="halflife">The time to decay by half.</param>
+        public static double DecayRate(double timestep, double halflife)
+        {
+            return Math.Exp(timestep / halflife * Math.Log(0.5));
+        }
     }
 }


### PR DESCRIPTION
When the buffer size is small, these allocations might be pretty significant.