### PR TITLE
Fix initial directory of open file dialog for loaded plugin instances

### DIFF
--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -16,7 +16,6 @@ namespace LiveSPICEVst
         public LiveSPICEPlugin Plugin { get; private set; }
 
         SchematicWindow schematicWindow = null;
-        string schematicPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "LiveSPICE"), "Examples");
 
         public EditorView(LiveSPICEPlugin plugin)
         {
@@ -76,18 +75,19 @@ namespace LiveSPICEVst
 
         private void LoadCircuitButton_Click(object sender, RoutedEventArgs e)
         {
-            OpenFileDialog dialog = new OpenFileDialog();
-
-            dialog.InitialDirectory = schematicPath;
-            dialog.Filter = "Circuit Schemas (*.schx)|*.schx";
+            string examples =
+               Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "LiveSPICE", "Examples");
+            string initialDirectory =
+                string.IsNullOrEmpty(Plugin.SchematicPath) ? examples : Path.GetDirectoryName(Plugin.SchematicPath);
+            OpenFileDialog dialog = new OpenFileDialog
+            {
+                InitialDirectory = initialDirectory,
+                Filter = "Circuit Schematics (*.schx)|*.schx"
+            };
 
             if (dialog.ShowDialog() == true)
             {
-                string path = dialog.FileName;
-
-                schematicPath = Path.GetDirectoryName(path);
-
-                Plugin.LoadSchematic(path);
+                Plugin.LoadSchematic(dialog.FileName);
 
                 UpdateSchematic();
             }

--- a/LiveSPICEVst/LiveSPICEPlugin.cs
+++ b/LiveSPICEVst/LiveSPICEPlugin.cs
@@ -27,6 +27,7 @@ namespace LiveSPICEVst
 
         public SimulationProcessor SimulationProcessor { get; private set; }
         public EditorView EditorView { get; set; }
+        public string SchematicPath { get { return SimulationProcessor.SchematicPath; } }
 
         System.Windows.Window window;
 

--- a/LiveSPICEVst/SimulationProcessor.cs
+++ b/LiveSPICEVst/SimulationProcessor.cs
@@ -97,7 +97,7 @@ namespace LiveSPICEVst
 
         public Schematic Schematic { get; private set; }
         public string SchematicPath { get; private set; }
-        public string SchematicName { get; private set; }
+        public string SchematicName { get { return System.IO.Path.GetFileNameWithoutExtension(SchematicPath); } }
 
         public double SampleRate
         {
@@ -165,14 +165,13 @@ namespace LiveSPICEVst
 
             Schematic = newSchematic;
 
-            SchematicName = System.IO.Path.GetFileNameWithoutExtension(path);
-
             SchematicPath = path;
         }
 
         public void ClearSchematic()
         {
             Schematic = null;
+            SchematicPath = "";
             circuit = null;
             InteractiveComponents.Clear();
         }


### PR DESCRIPTION
Currently, if you load a schematic, then reopen the open file dialog, it initializes to the path of the schematic, as expected. However, if you save the project using the VST plugin, close, reload the project, and then browse for a schematic, it will initialize to Documents\LiveSPICE\Examples instead of the path of the current schematic.

This PR fixes that by getting the schematic path from the plugin, instead of remembering it when it is loaded.