### PR TITLE
Fix crash when viewing schematic in VST plugin

### DIFF
--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -111,6 +111,7 @@ namespace LiveSPICEVst
                         DataContext = Plugin.SimulationProcessor.Schematic,
                         Title = Plugin.SimulationProcessor.SchematicName
                     };
+                    schematicWindow.Closed += (o, e2) => schematicWindow = null;
                 }
                 
                 schematicWindow.Show();


### PR DESCRIPTION
I found that if you have a project with two VST plugin instances A and B, and you do the following:

1. Go to A, click View, close schematic window
2. Go to B, click View, close schematic window
3. Go to A, click View -> crash

This PR fixes this. However, I'm not sure if it's really the best fix? Seems like maybe its kind of a hack?