### PR TITLE
Command line parameters parsing in Test, Gaussian elimination benchmarks.

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
+    <PackageReference Include="MathNet.Numerics" Version="4.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="MathNet.Numerics" Version="4.12.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Circuit\Circuit.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Benchmarks/GaussianElimination.cs
+++ b/Benchmarks/GaussianElimination.cs
@@ -210,8 +210,6 @@ namespace Benchmarks
             {
                 var Ab = _data[iteration].JaggedArray;
 
-                const double tiny = 0.00001;
-
                 // Solve for dx.
                 // For each variable in the system...
                 for (int j = 0; j + 1 < N; ++j)
@@ -245,7 +243,7 @@ namespace Benchmarks
                     for (int i = j + 1; i < M; ++i)
                     {
                         double s = Ab[i][j] / p;
-                        if (Math.Abs(s) >= tiny)
+                        if (s != 0.0)
                         {
                             int jj;
                             for (jj = j + 1; jj <= (N - vectorLength); jj += vectorLength)

--- a/Benchmarks/GaussianElimination.cs
+++ b/Benchmarks/GaussianElimination.cs
@@ -38,7 +38,7 @@ namespace Benchmarks
 
                 return (RowMajorArray: ab.ToRowMajorArray(),
                         ColumnMajorArray: ab.ToColumnMajorArray(),
-                        JaggedArray: ab.ToRowArrays(),
+                        JaggedArray: ab.ToRowArrays().Select(a => a.Concat(Enumerable.Repeat(0d, System.Numerics.Vector<double>.Count)).ToArray()).ToArray(),
                         A: A,
                         b: b);
 
@@ -313,7 +313,7 @@ namespace Benchmarks
                         if (s != 0.0)
                         {
                             int jj;
-                            for (jj = j + 1; jj <= (N - vectorLength); jj += vectorLength)
+                            for (jj = j + 1; jj <= N; jj += vectorLength)
                             {
                                 var source = new System.Numerics.Vector<double>(Ab[j], jj);
                                 var target = new System.Numerics.Vector<double>(Ab[i], jj);

--- a/Benchmarks/GaussianElimination.cs
+++ b/Benchmarks/GaussianElimination.cs
@@ -1,0 +1,278 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Complex;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    [HardwareCounters(
+        HardwareCounter.BranchMispredictions,
+        HardwareCounter.BranchInstructions,
+        HardwareCounter.CacheMisses)]
+    public class GaussianElimination
+    {
+        [Params(12)]
+        public int M { get; set; }
+        public int N => M;
+        public int Size => 100000;
+
+        private const int seed = 12345;
+
+
+        private (double[] RowMajorArray, double[] ColumnMajorArray, double[][] JaggedArray, Matrix<double> A, Vector<double> b)[] _data;
+
+        [IterationSetup]
+        public void Setup()
+        {
+            var rnd = new Random(seed);
+            _data = Enumerable.Range(0, Size).Select(_ =>
+            {
+                var A = Matrix<double>.Build.Random(M, N, rnd.Next());
+                var x = Vector<double>.Build.Random(M, rnd.Next());
+                var b = A * x;
+
+                var ab = A.InsertColumn(N, b);
+
+                return (RowMajorArray: ab.ToRowMajorArray(),
+                        ColumnMajorArray: ab.ToColumnMajorArray(),
+                        JaggedArray: ab.ToRowArrays(),
+                        A: A,
+                        b: b);
+
+            }).ToArray();
+        }
+
+        [Benchmark]
+        public void CompactColumnMajor()
+        {
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                var Ab = _data[iteration].ColumnMajorArray;
+
+                // Solve for dx.
+                // For each variable in the system...
+                for (int j = 0; j + 1 < N; ++j)
+                {
+                    int pi = j;
+                    double max = Math.Abs(Ab[j * M + j]);
+
+                    // Find a pivot row for this variable.
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        // if(|JxF[i][j]| > max) { pi = i, max = |JxF[i][j]| }
+                        double maxj = Math.Abs(Ab[i + M * j]);
+                        if (maxj > max)
+                        {
+                            pi = i;
+                            max = maxj;
+                        }
+                    }
+
+                    // Swap pivot row with the current row.
+                    if (pi != j)
+                    {
+                        for (int n = 0; n <= N; n++)
+                        {
+                            var tmp = Ab[n * M + pi];
+                            Ab[n * M + pi] = Ab[n * M + j];
+                            Ab[n * M + j] = tmp;
+                        }
+                    }
+
+                    // Eliminate the rows after the pivot.
+                    double p = Ab[j * M + j];
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        double s = Ab[i + M * j] / p;
+                        if (s != 0.0)
+                            for (int ij = j + 1; ij <= N; ++ij)
+                                Ab[i + M * ij] -= Ab[j + M * ij] * s;
+                    }
+                }
+            }
+        }
+
+
+        [Benchmark]
+        public void CompactRowMajor()
+        {
+
+            var eN = N + 1;
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                var Ab = _data[iteration].RowMajorArray;
+
+                // Solve for dx.
+                // For each variable in the system...
+                for (int j = 0; j + 1 < N; ++j)
+                {
+                    int pi = j;
+                    double max = Math.Abs(Ab[j * eN + j]);
+
+                    // Find a pivot row for this variable.
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        // if(|JxF[i][j]| > max) { pi = i, max = |JxF[i][j]| }
+                        double maxj = Math.Abs(Ab[i * eN + j]);
+                        if (maxj > max)
+                        {
+                            pi = i;
+                            max = maxj;
+                        }
+                    }
+
+                    // Swap pivot row with the current row.
+                    if (pi != j)
+                    {
+                        for (int n = 0; n <= N; n++)
+                        {
+                            var tmp = Ab[n + pi * eN];
+                            Ab[n + pi * eN] = Ab[n + j * eN];
+                            Ab[n + j * eN] = tmp;
+                        }
+                    }
+
+                    // Eliminate the rows after the pivot.
+                    double p = Ab[j * eN + j];
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        double s = Ab[i * eN + j] / p;
+                        if (s != 0.0)
+                            for (int ij = j + 1; ij <= N; ++ij)
+                                Ab[i * eN + ij] -= Ab[j * eN + ij] * s;
+                    }
+                }
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ArrayOfArrays()
+        {
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                var Ab = _data[iteration].JaggedArray;
+
+                // Solve for dx.
+                // For each variAb2le in the system...
+                for (int j = 0; j + 1 < N; ++j)
+                {
+                    int pi = j;
+                    double max = Math.Abs(Ab[j][j]);
+
+                    // Find a pivot row for this variable.
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        // if(|JxF[i][j]| > max) { pi = i, max = |JxF[i][j]| }
+                        double maxj = Math.Abs(Ab[i][j]);
+                        if (maxj > max)
+                        {
+                            pi = i;
+                            max = maxj;
+                        }
+                    }
+
+                    // Swap pivot row with the current row.
+                    if (pi != j)
+                    {
+                        var tmp = Ab[pi];
+                        Ab[pi] = Ab[j];
+                        Ab[j] = tmp;
+                    }
+
+                    // Eliminate the rows after the pivot.
+                    double p = Ab[j][j];
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        double s = Ab[i][j] / p;
+                        if (s != 0.0d)
+                        {
+                            for (int jj = j + 1; jj <= N; ++jj)
+                            {
+                                Ab[i][jj] -= Ab[j][jj] * s;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ArrayOfArraysVectorized()
+        {
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                var Ab = _data[iteration].JaggedArray;
+
+                const double tiny = 0.00001;
+
+                // Solve for dx.
+                // For each variable in the system...
+                for (int j = 0; j + 1 < N; ++j)
+                {
+                    int pi = j;
+                    double max = Math.Abs(Ab[j][j]);
+
+                    // Find a pivot row for this variable.
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        // if(|JxF[i][j]| > max) { pi = i, max = |JxF[i][j]| }
+                        double maxj = Math.Abs(Ab[i][j]);
+                        if (maxj > max)
+                        {
+                            pi = i;
+                            max = maxj;
+                        }
+                    }
+
+                    // Swap pivot row with the current row.
+                    if (pi != j)
+                    {
+                        var tmp = Ab[pi];
+                        Ab[pi] = Ab[j];
+                        Ab[j] = tmp;
+                    }
+
+                    var vectorLength = System.Numerics.Vector<double>.Count;
+                    // Eliminate the rows after the pivot.
+                    double p = Ab[j][j];
+                    for (int i = j + 1; i < M; ++i)
+                    {
+                        double s = Ab[i][j] / p;
+                        if (Math.Abs(s) >= tiny)
+                        {
+                            int jj;
+                            for (jj = j + 1; jj <= (N - vectorLength); jj += vectorLength)
+                            {
+                                var source = new System.Numerics.Vector<double>(Ab[j], jj);
+                                var target = new System.Numerics.Vector<double>(Ab[i], jj);
+                                var res = target - (source * s);
+                                res.CopyTo(Ab[i], jj);
+                            }
+                            for (; jj <= N; ++jj)
+                            {
+                                Ab[i][jj] -= Ab[j][jj] * s;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void MathNetSolve()
+        {
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                _data[iteration].A.Solve(_data[iteration].b);
+            }
+        }
+
+    }
+}

--- a/Benchmarks/GaussianElimination.cs
+++ b/Benchmarks/GaussianElimination.cs
@@ -1,13 +1,9 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
+using Circuit;
 using MathNet.Numerics.LinearAlgebra;
-using MathNet.Numerics.LinearAlgebra.Complex;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Benchmarks
 {
@@ -153,6 +149,17 @@ namespace Benchmarks
         }
 
         [Benchmark(Baseline = true)]
+        public void Current()
+        {
+            for (int iteration = 0; iteration < Size; iteration++)
+            {
+                var Ab = _data[iteration].JaggedArray;
+
+                Simulation.RowReduce(Ab, M, N);
+            }
+        }
+
+        [Benchmark]
         public void ArrayOfArrays()
         {
             for (int iteration = 0; iteration < Size; iteration++)

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Running;
+using System;
+
+namespace Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run(typeof(Program).Assembly);
+        }
+    }
+}

--- a/Circuit/Simulation/Simulation.cs
+++ b/Circuit/Simulation/Simulation.cs
@@ -452,7 +452,7 @@ namespace Circuit
         }
 
         // A human readable implementation of RowReduce.
-        private static void RowReduce(double[][] Ab, int M, int N)
+        public static void RowReduce(double[][] Ab, int M, int N)
         {
             // Solve for dx.
             // For each variable in the system...

--- a/LiveSPICE.sln
+++ b/LiveSPICE.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30611.23
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31521.260
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Circuit", "Circuit\Circuit.csproj", "{5E788E8B-995B-4B54-B3A9-040D65D5509A}"
 EndProject
@@ -28,6 +28,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LiveSPICEVst", "LiveSPICEVst", "{6DD7DA6B-5277-45C3-ACBD-8306D27528D0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputerAlgebra.Plotting", "ComputerAlgebra\ComputerAlgebra.Plotting\ComputerAlgebra.Plotting.csproj", "{51F8BCEC-5C29-46BA-8448-06B516715840}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{ECCE5E4E-730F-4A2D-A772-3AC922D9ACD2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +85,10 @@ Global
 		{51F8BCEC-5C29-46BA-8448-06B516715840}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51F8BCEC-5C29-46BA-8448-06B516715840}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51F8BCEC-5C29-46BA-8448-06B516715840}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECCE5E4E-730F-4A2D-A772-3AC922D9ACD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECCE5E4E-730F-4A2D-A772-3AC922D9ACD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECCE5E4E-730F-4A2D-A772-3AC922D9ACD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECCE5E4E-730F-4A2D-A772-3AC922D9ACD2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/CommandLineExtensions.cs
+++ b/Tests/CommandLineExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.Invocation;
+using System.CommandLine;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    public static class CommandExtensions
+    {
+        public static Command WithArgument<T>(this Command command, Argument<T> argument)
+        {
+            command.AddArgument(argument);
+            return command;
+        }
+
+        public static Command WithArgument<T>(this Command command, string name, string description, IArgumentArity? arity = null)
+        {
+            var argument = new Argument<T>(name)
+            {
+                Description = description,
+                Arity = arity ?? ArgumentArity.ExactlyOne
+            };
+
+            return command.WithArgument(argument);
+        }
+
+        public static TCommand WithCommand<TCommand>(this TCommand command, string name, string description, Action<Command> commandBuilder)
+            where TCommand : Command
+        {
+            var subCommand = new Command(name, description);
+            commandBuilder.Invoke(subCommand);
+            command.AddCommand(subCommand);
+            return command;
+        }
+
+        public static TCommand WithGlobalOption<TCommand>(this TCommand command, Option option)
+            where TCommand : Command
+        {
+            command.AddGlobalOption(option);
+            return command;
+        }
+
+        public static Command WithHandler(this Command command, ICommandHandler handler)
+        {
+            command.Handler = handler;
+            return command;
+        }
+
+        public static Command WithOption<T>(this Command command, Option<T> option)
+        {
+            command.AddOption(option);
+            return command;
+        }
+
+        public static Command WithOption<T>(this Command command, string[] aliases, string description)
+        {
+            var option = new Option<T>(aliases, description);
+            command.AddOption(option);
+            return command;
+        }
+
+        public static Command WithOption<T>(this Command command, string[] aliases, Func<T> getDefaultValue, string description)
+        {
+            var option = new Option<T>(
+                aliases,
+                getDefaultValue,
+                description
+            );
+
+            command.AddOption(option);
+            return command;
+        }
+    }
+}

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -15,26 +15,26 @@ namespace Tests
         static async Task<int> Main(string[] args)
         {
             var rootCommand = new RootCommand().WithCommand("test", "Run tests", c => c
-                                                    .WithArgument<string>("searchPath", "Files to test")
+                                                    .WithArgument<string>("pattern", "Glob pattern for files to test")
                                                     .WithOption<bool>(new[] { "--plot" }, "Plot results")
+                                                    .WithOption(new[] { "--samples" }, () => 4800, "Samples")
                                                     .WithHandler(CommandHandler.Create<string, bool, int, int, int, int>(Test)))
                                                .WithCommand("benchmark", "Run benchmarks", c => c
-                                                    .WithArgument<string>("searchPath", "Files to benchmark")
+                                                    .WithArgument<string>("pattern", "Glob pattern for files to benchmark")
                                                     .WithHandler(CommandHandler.Create<string, int, int, int>(Benchmark)))
                                                .WithGlobalOption(new Option<int>("--sampleRate", () => 48000, "Sample Rate"))
-                                               .WithGlobalOption(new Option<int>("--samples", () => 4800, "Samples"))
                                                .WithGlobalOption(new Option<int>("--oversample", () => 8, "Oversample"))
                                                .WithGlobalOption(new Option<int>("--iterations", () => 8, "Iterations"));
 
-            return rootCommand.InvokeAsync(args).Result;
+            return await rootCommand.InvokeAsync(args);
         }
 
-        public static void Test(string searchPath, bool plot, int sampleRate, int samples, int oversample, int iterations)
+        public static void Test(string pattern, bool plot, int sampleRate, int samples, int oversample, int iterations)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Info };
             var tester = new Test();
 
-            foreach (var circuit in GetCircuits(searchPath, log))
+            foreach (var circuit in GetCircuits(pattern, log))
             {
                 var outputs = tester.Run(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, samples, oversample, iterations);
                 if (plot)
@@ -44,11 +44,11 @@ namespace Tests
             }
         }
 
-        public static void Benchmark(string searchPath, int sampleRate, int oversample, int iterations)
+        public static void Benchmark(string pattern, int sampleRate, int oversample, int iterations)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Info };
             var tester = new Test();
-            foreach (var circuit in GetCircuits(searchPath, log))
+            foreach (var circuit in GetCircuits(pattern, log))
             {
                 tester.Benchmark(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, oversample, iterations, log: log);
             }

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -106,14 +106,15 @@ namespace Tests
             int Oversample,
             int Iterations,
             Expression Input = null,
-            IEnumerable<Expression> Outputs = null)
+            IEnumerable<Expression> Outputs = null,
+            ILog log = null)
         {
             Analysis analysis = null;
             double analyzeTime = Benchmark(1, () => analysis = C.Analyze());
             System.Console.WriteLine("Circuit.Analyze time: {0:G3} ms", analyzeTime * 1000);
 
             TransientSolution TS = null;
-            double solveTime = Benchmark(1, () => TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample)));
+            double solveTime = Benchmark(1, () => TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample), log));
             System.Console.WriteLine("TransientSolution.Solve time: {0:G3} ms", solveTime * 1000);
 
             // By default, pass Vin to each input of the circuit.

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -7,6 +7,8 @@
     <Copyright>Copyright ©  2020</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Circuit\Circuit.csproj" />
@@ -16,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi. I've tested how memory layout of arrays affects performance of the Gaussian elimination method in the inner loop of the simulation lambda and here are the results:
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1110 (21H1/May2021Update)
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.6.21355.2
  [Host]     : .NET 6.0.0 (6.0.21.35212), X64 RyuJIT
  Job-WMMCQC : .NET 6.0.0 (6.0.21.35212), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                  Method |  M |     Mean |   Error |  StdDev | Ratio | RatioSD | CacheMisses/Op | BranchMispredictions/Op | BranchInstructions/Op |      Gen 0 |     Allocated |
|------------------------ |--- |---------:|--------:|--------:|------:|--------:|---------------:|------------------------:|----------------------:|-----------:|--------------:|
|      CompactColumnMajor | 12 | 168.1 ms | 3.26 ms | 3.62 ms |  1.09 |    0.03 |      5,895,782 |               3,725,107 |           292,493,722 |          - |         336 B |
|         CompactRowMajor | 12 | 170.8 ms | 3.35 ms | 4.47 ms |  1.10 |    0.04 |      5,845,524 |               3,755,540 |           268,238,848 |          - |         336 B |
|           ArrayOfArrays | 12 | 155.1 ms | 3.09 ms | 3.68 ms |  1.00 |    0.00 |      6,609,769 |               3,571,795 |           257,758,787 |          - |         336 B |
| ArrayOfArraysVectorized | 12 | 135.8 ms | 2.64 ms | 4.10 ms |  0.88 |    0.04 |      6,657,404 |               2,985,282 |           198,694,853 |          - |         336 B |
|            MathNetSolve | 12 | 312.0 ms | 6.08 ms | 9.46 ms |  2.02 |    0.09 |     10,237,689 |               4,685,561 |           467,613,872 | 49000.0000 | 210,400,336 B |

I've checked also how well perform MathNet's LU factorization, and it's significantly slower. It might be superior in cases where A matrix is constant, which is unfortunately not our case.
Looking at the results I've found, that only vectorized method performs about 10% better than current implementation. I would be happy to se how it performs  on a different machine, because I'm currently testing it on my laptop and thermal throttling might skew the results a little bit ;)
Sidenote: messing with the equation-order in MNA, seems to have bigger influence on the performance, and sometimes stability of the solution. I'm suspecting, that it might be related to some cache-misses, but this requires more investigation ;)

I've also managed to fix this little TODO:
```// TODO: Make these command line arguments.```
using fresh beta version of System.CommandLine package ;)