### PR TITLE
Ground symbol as a named wire

### DIFF
--- a/Circuit/Components/Ground.cs
+++ b/Circuit/Components/Ground.cs
@@ -7,9 +7,13 @@ namespace Circuit
     /// </summary>
     [Category("Generic")]
     [DisplayName("Ground")]
-    public class Ground : OneTerminal
+    public class Ground : NamedWire
     {
-        public Ground() { Name = "GND1"; }
+        public Ground()
+        {
+            Name = "GND1";
+            WireName = "GND";
+        }
 
         public static void Analyze(Analysis Mna, Node G)
         {
@@ -23,7 +27,7 @@ namespace Circuit
 
         public override void LayoutSymbol(SymbolLayout Sym)
         {
-            base.LayoutSymbol(Sym);
+            Sym.AddTerminal(Terminal, new Coord(0, 0));
 
             Sym.AddLoop(EdgeType.Black,
                 new Coord(-10, 0),


### PR DESCRIPTION
I've noticed that adding multiple ground symbols to the schematic creates additional nodes for them. This should fix that problem :)