### PR TITLE
Schematic rendering misalignment

### DIFF
--- a/LiveSPICE/Controls/Editor/SelectionTool.cs
+++ b/LiveSPICE/Controls/Editor/SelectionTool.cs
@@ -26,7 +26,6 @@ namespace LiveSPICE
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Center,
                 Visibility = Visibility.Hidden,
-                SnapsToDevicePixels = true,
                 Data = new RectangleGeometry()
             };
         }

--- a/LiveSPICE/Controls/Editor/WireTool.cs
+++ b/LiveSPICE/Controls/Editor/WireTool.cs
@@ -20,10 +20,12 @@ namespace LiveSPICE
                 Fill = null,
                 Stroke = ElementControl.HighlightPen.Brush,
                 StrokeThickness = 1,
+                StrokeStartLineCap = PenLineCap.Round,
+                StrokeEndLineCap = PenLineCap.Round,
+                StrokeLineJoin = PenLineJoin.Round,
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Center,
                 Visibility = Visibility.Hidden,
-                SnapsToDevicePixels = true,
                 Data = new PathGeometry()
             };
         }
@@ -49,8 +51,8 @@ namespace LiveSPICE
             {
                 LineGeometry line = new LineGeometry()
                 {
-                    StartPoint = Target.ToPoint(points[i]) + new Vector(0.5, -0.5),
-                    EndPoint = Target.ToPoint(points[i + 1]) + new Vector(0.5, -0.5)
+                    StartPoint = Target.ToPoint(points[i]),
+                    EndPoint = Target.ToPoint(points[i + 1])
                 };
                 ((PathGeometry)path.Data).AddGeometry(line);
             }

--- a/LiveSPICE/Controls/SchematicViewer.xaml
+++ b/LiveSPICE/Controls/SchematicViewer.xaml
@@ -9,6 +9,5 @@
     <ScrollViewer x:Name="scroll" 
                   HorizontalScrollBarVisibility="Auto" 
                   VerticalScrollBarVisibility="Auto" 
-                  Background="LightGray"
-                  UseLayoutRounding="True" />
+                  Background="LightGray" />
 </UserControl>

--- a/LiveSPICE/Utils/ImageButton.cs
+++ b/LiveSPICE/Utils/ImageButton.cs
@@ -29,7 +29,7 @@ namespace LiveSPICE
             {
                 if (value != null)
                 {
-                    enabled = new Image() { Source = value, SnapsToDevicePixels = true };
+                    enabled = new Image() { Source = value };
                     if (enabled != null)
                     {
                         disabled = MakeDisabledImage(enabled);
@@ -97,7 +97,7 @@ namespace LiveSPICE
             bitmap.AddDirtyRect(new Int32Rect(0, 0, bitmap.PixelWidth, bitmap.PixelHeight));
 
             bitmap.Unlock();
-            return new Image() { Source = bitmap, SnapsToDevicePixels = true };
+            return new Image() { Source = bitmap };
         }
     }
 }

--- a/LiveSPICE/Utils/MenuItemIcon.cs
+++ b/LiveSPICE/Utils/MenuItemIcon.cs
@@ -28,7 +28,7 @@ namespace LiveSPICE
             {
                 if (value != null)
                 {
-                    enabled = new Image() { Source = value, SnapsToDevicePixels = true };
+                    enabled = new Image() { Source = value };
                     if (enabled != null)
                     {
                         disabled = ImageButton.MakeDisabledImage(enabled);

--- a/SchematicControls/ElementControl.cs
+++ b/SchematicControls/ElementControl.cs
@@ -63,7 +63,6 @@ namespace SchematicControls
             element = E;
             element.Tag = this;
 
-            UseLayoutRounding = true;
             Background = Brushes.Transparent;
 
             foreach (Circuit.Terminal i in E.Terminals)

--- a/SchematicControls/ElementControl.cs
+++ b/SchematicControls/ElementControl.cs
@@ -16,8 +16,8 @@ namespace SchematicControls
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ElementControl), new FrameworkPropertyMetadata(typeof(ElementControl)));
         }
 
-        public static Pen HighlightPen = new Pen(Brushes.Gray, 0.5f) { DashStyle = DashStyles.Dash };
-        public static Pen SelectedPen = new Pen(Brushes.Blue, 0.5f) { DashStyle = DashStyles.Dash };
+        public static Pen HighlightPen = new Pen(Brushes.Gray, 0.5f) { DashStyle = DashStyles.Dash }.GetAsFrozen() as Pen;
+        public static Pen SelectedPen = new Pen(Brushes.Blue, 0.5f) { DashStyle = DashStyles.Dash }.GetAsFrozen() as Pen;
 
         private Pen pen = null;
         public Pen Pen { get { return pen; } set { pen = value; InvalidateVisual(); } }
@@ -84,21 +84,20 @@ namespace SchematicControls
 
         public static double TerminalSize = 2.0;
         public static double EdgeThickness = 1.0;
-        public static GuidelineSet Guidelines = new GuidelineSet(new double[] { EdgeThickness / 2 }, new double[] { EdgeThickness / 2 });
 
         public static Brush WireBrush = Brushes.DarkBlue;
-        public static Pen WirePen = new Pen(WireBrush, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen TerminalPen = new Pen(Brushes.Black, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
+        public static Pen WirePen = new Pen(WireBrush, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen TerminalPen = new Pen(Brushes.Black, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
 
-        public static Pen BlackPen = new Pen(Brushes.Black, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen GrayPen = new Pen(Brushes.Gray, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen RedPen = new Pen(Brushes.Red, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen GreenPen = new Pen(Brushes.Lime, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen BluePen = new Pen(Brushes.Blue, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen YellowPen = new Pen(Brushes.Yellow, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen CyanPen = new Pen(Brushes.Cyan, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen MagentaPen = new Pen(Brushes.Magenta, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
-        public static Pen OrangePen = new Pen(Brushes.Orange, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
+        public static Pen BlackPen = new Pen(Brushes.Black, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen GrayPen = new Pen(Brushes.Gray, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen RedPen = new Pen(Brushes.Red, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen GreenPen = new Pen(Brushes.Lime, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen BluePen = new Pen(Brushes.Blue, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen YellowPen = new Pen(Brushes.Yellow, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen CyanPen = new Pen(Brushes.Cyan, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen MagentaPen = new Pen(Brushes.Magenta, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
+        public static Pen OrangePen = new Pen(Brushes.Orange, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round }.GetAsFrozen() as Pen;
 
         public static Pen MapToPen(Circuit.EdgeType Edge)
         {

--- a/SchematicControls/SymbolControl.cs
+++ b/SchematicControls/SymbolControl.cs
@@ -20,8 +20,8 @@ namespace SchematicControls
     {
         private static readonly Pen TextOutline = new Pen(new SolidColorBrush(Color.FromArgb(32, 0, 0, 0)), 0.2);
 
-        static SymbolControl() 
-        { 
+        static SymbolControl()
+        {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(SymbolControl), new FrameworkPropertyMetadata(typeof(SymbolControl)));
         }
 
@@ -97,7 +97,7 @@ namespace SchematicControls
         {
             get
             {
-                Circuit.Coord offset = (layout.LowerBound + layout.UpperBound) / 2;
+                var offset = (layout.LowerBound + layout.UpperBound) / 2;
 
                 Matrix transform = new Matrix();
                 transform.Translate(-offset.x, -offset.y);
@@ -115,12 +115,9 @@ namespace SchematicControls
         }
 
         protected DrawingContext dc;
-        protected override void OnRender(DrawingContext drawingContext)
+        protected override void OnRender(DrawingContext dc)
         {
             Matrix transform = Transform;
-
-            dc = drawingContext;
-            dc.PushGuidelineSet(SymbolControl.Guidelines);
 
             DrawLayout(
                 layout, dc, transform, Pen, ShowText ? FontFamily : null, FontWeight, FontSize,
@@ -131,9 +128,6 @@ namespace SchematicControls
                 dc.DrawRectangle(null, SelectedPen, bounds);
             else if (Highlighted)
                 dc.DrawRectangle(null, HighlightPen, bounds);
-
-            dc.Pop();
-            dc = null;
         }
 
         private static Point T(Matrix Tx, Circuit.Point x) { return Tx.Transform(new Point(x.x, x.y)); }
@@ -142,8 +136,6 @@ namespace SchematicControls
             Circuit.SymbolLayout Layout, DrawingContext Context, Matrix Tx, Pen Pen, FontFamily FontFamily,
             FontWeight FontWeight, double FontSize, double PixelsPerDip)
         {
-            Context.PushGuidelineSet(Guidelines);
-
             foreach (Circuit.SymbolLayout.Shape i in Layout.Lines)
                 Context.DrawLine(
                     Pen ?? MapToPen(i.Edge),
@@ -227,8 +219,6 @@ namespace SchematicControls
                 Pen pen = MapToPen(i.ConnectedTo is null ? Circuit.EdgeType.Red : Circuit.EdgeType.Wire);
                 Context.DrawRectangle(pen.Brush, pen, new Rect(x - dx, x + dx));
             }
-
-            Context.Pop();
         }
 
         public static void DrawLayout(

--- a/SchematicControls/WireControl.cs
+++ b/SchematicControls/WireControl.cs
@@ -22,8 +22,6 @@ namespace SchematicControls
 
         protected override void OnRender(DrawingContext dc)
         {
-            dc.PushGuidelineSet(Guidelines);
-
             // This isn't pointless, it makes WPF mouse hit tests succeed near the wire instead of exactly on it.
             dc.DrawRectangle(Brushes.Transparent, null, new Rect(-2, -2, ActualWidth + 4, ActualHeight + 4));
 
@@ -40,8 +38,6 @@ namespace SchematicControls
             Vector dx = new Vector(WireTerminalSize / 2, WireTerminalSize / 2);
             foreach (Point x in new[] { ToPoint(wire.A - wire.LowerBound), ToPoint(wire.B - wire.LowerBound) })
                 dc.DrawRectangle(WirePen.Brush, WirePen, new Rect(x - dx, x + dx));
-
-            dc.Pop();
         }
 
         protected static Pen SelectedWirePen = new Pen(Brushes.Blue, EdgeThickness) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };


### PR DESCRIPTION
While working on vacuum tubes, I'm fixing some minor issues that I'm stumbling upon. 😃 This PR fixes some component misalignment issues that where caused by using a mix of `Guidelines`, `LayoutRounding` and `SnapToDevicePixels`. They are usefull for some extra sharp one-pixel wide separators, but when used with vector graphics they tend to cause issues with alignment, jittery image when zooming and panning, etc. I've also added freezing to all static pens, as it drastically improves rendering performance.
Before:
![image](https://user-images.githubusercontent.com/19556976/134971571-272a0bb1-0998-47c7-b0e8-e0abf7e4533b.png)
After:
![image](https://user-images.githubusercontent.com/19556976/134971654-98eef618-117a-4a8d-9e0e-4a23b4e073e0.png)
