### PR TITLE
koren model fixes

### DIFF
--- a/Circuit/Components/VacuumTubes/Pentode.cs
+++ b/Circuit/Components/VacuumTubes/Pentode.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Text;
 
 namespace Circuit.Components
 {
@@ -113,7 +112,7 @@ namespace Circuit.Components
             var b = (knee - vg) / (2 * knee * rg1);
             var c = (-a * Math.Pow(vg - knee, 2)) - (b * (vg - knee));
 
-            var ig = Call.If(vgk < vg - knee, 0, Call.If(vgk > vg + knee, (vgk - vg)/ rg1, a*vgk*vgk + b*vgk + c));
+            var ig = Call.If(vgk < vg - knee, 0, Call.If(vgk > vg + knee, (vgk - vg) / rg1, a * vgk * vgk + b * vgk + c));
             var ig2 = iKoren / Kg2;
             var ik = -(ip + ig + ig2);
 
@@ -124,8 +123,7 @@ namespace Circuit.Components
         }
         private static Expression Ln1Exp(Expression x)
         {
-            return Call.Ln(1 + Call.Exp(x));
-            //return Call.If(x > 5, x, Call.Ln(1 + Call.Exp(x)));
+            return Call.If(x > 50, x, Call.Ln(1 + Call.Exp(x)));
         }
     }
 }

--- a/Circuit/Components/VacuumTubes/Pentode.cs
+++ b/Circuit/Components/VacuumTubes/Pentode.cs
@@ -104,13 +104,13 @@ namespace Circuit.Components
             var iKoren = Call.If(E1 > 0, Binary.Power(E1, Ex), 0);
             var ip = Call.If(vpk > 0, iKoren / Kg1 * Call.ArcTan(vpk / Kvb), 0);
 
-            var vg = (double)Vg;
-            var knee = (double)Kn;
-            var rg1 = (double)Rgk;
+            var vg = (Real)Vg;
+            var knee = (Real)Kn;
+            var rg1 = (Real)Rgk;
 
             var a = 1 / (4 * knee * rg1);
-            var b = (knee - vg) / (2 * knee * rg1);
-            var c = (-a * Math.Pow(vg - knee, 2)) - (b * (vg - knee));
+            var b = ((Expression)Kn - Vg) / (2 * knee * rg1);
+            var c = (-a * Binary.Power(vg - knee, 2)) - (b * (vg - knee));
 
             var ig = Call.If(vgk < vg - knee, 0, Call.If(vgk > vg + knee, (vgk - vg) / rg1, a * vgk * vgk + b * vgk + c));
             var ig2 = iKoren / Kg2;

--- a/Circuit/Components/VacuumTubes/Pentode.cs
+++ b/Circuit/Components/VacuumTubes/Pentode.cs
@@ -36,6 +36,18 @@ namespace Circuit.Components
         [Serialize, Category("Koren"), Browsable(true)]
         public double Ex { get { return _ex; } set { _ex = value; NotifyChanged(nameof(Ex)); } }
 
+        private Quantity rgk = new Quantity(2e4, Units.Ohm);
+        [Serialize, Category("Koren"), Description("Grid resistance")]
+        public Quantity Rgk { get { return rgk; } set { if (rgk.Set(value)) NotifyChanged(nameof(Rgk)); } }
+
+        private Quantity kn = new Quantity(3, Units.V);
+        [Serialize, Category("Koren"), Description("Knee size")]
+        public Quantity Kn { get { return kn; } set { if (kn.Set(value)) NotifyChanged(nameof(Kn)); } }
+
+        private Quantity vg = new Quantity(13, Units.V);
+        [Serialize, Category("Koren")]
+        public Quantity Vg { get { return vg; } set { if (vg.Set(value)) NotifyChanged(nameof(Vg)); } }
+
         public Pentode()
         {
             _plate = new Terminal(this, "P");
@@ -93,9 +105,9 @@ namespace Circuit.Components
             var iKoren = Call.If(E1 > 0, Binary.Power(E1, Ex), 0);
             var ip = Call.If(vpk > 0, iKoren / Kg1 * Call.ArcTan(vpk / Kvb), 0);
 
-            var vg = 13d;
-            var knee = 3d;
-            var rg1 = 2000d;
+            var vg = (double)Vg;
+            var knee = (double)Kn;
+            var rg1 = (double)Rgk;
 
             var a = 1 / (4 * knee * rg1);
             var b = (knee - vg) / (2 * knee * rg1);

--- a/Circuit/Components/VacuumTubes/Triode.cs
+++ b/Circuit/Components/VacuumTubes/Triode.cs
@@ -148,13 +148,13 @@ namespace Circuit
                     Expression E1 = Ln1Exp(Kp * (1.0 / Mu + Vgk * Binary.Power(Kvb + Vpk * Vpk, -0.5))) * Vpk / Kp;
                     ip = Mna.AddUnknownEqualTo(Call.If(E1 > 0, 2d * (E1 ^ Ex) / Kg, 0));
 
-                    var vg = (double)Vg;
-                    var knee = (double)Kn;
-                    var rg1 = (double)Rgk;
+                    var vg = (Real)Vg;
+                    var knee = (Real)Kn;
+                    var rg1 = (Real)Rgk;
 
                     var a = 1 / (4 * knee * rg1);
                     var b = (knee - vg) / (2 * knee * rg1);
-                    var c = (-a * Math.Pow(vg - knee, 2)) - (b * (vg - knee));
+                    var c = (-a * Binary.Power(vg - knee, 2)) - (b * (vg - knee));
 
                     ig = Mna.AddUnknownEqualTo(Call.If(Vgk < vg - knee, 0, Call.If(Vgk > vg + knee, (Vgk - vg) / rg1, a * Vgk * Vgk + b * Vgk + c)));
                     ik = -(ip + ig);
@@ -164,17 +164,19 @@ namespace Circuit
                     ig = Call.If(exg > -50, Gg * Binary.Power(Ln1Exp(exg) / Cg, Xi), 0) + Ig0;
                     Expression exk = C * ((Vpk / Mu) + Vgk);
                     ik = Call.If(exk > -50, -G * Binary.Power(Ln1Exp(exk) / C, Gamma), 0);
-                    if (SimulateCapacitances)
-                    {
-                        Capacitor.Analyze(Mna, Name + "_cgp", p, g, _cgp);
-                        Capacitor.Analyze(Mna, Name + "_cgk", g, k, _cgk);
-                        Capacitor.Analyze(Mna, Name + "_cpk", p, k, _cpk);
-                    }
                     ip = -(ik + ig);
                     break;
                 default:
                     throw new NotImplementedException("Triode model " + model.ToString());
             }
+
+            if (SimulateCapacitances)
+            {
+                Capacitor.Analyze(Mna, Name + "_cgp", p, g, _cgp);
+                Capacitor.Analyze(Mna, Name + "_cgk", g, k, _cgk);
+                Capacitor.Analyze(Mna, Name + "_cpk", p, k, _cpk);
+            }
+
             Mna.AddTerminal(p, ip);
             Mna.AddTerminal(g, ig);
             Mna.AddTerminal(k, ik);


### PR DESCRIPTION
I've changed grid current calculation to method proposed by Cohen and Helie in [[1]](https://www.dafx.de/paper-archive/2010/DAFx10/CohenHelie_DAFx10_P45.pdf), [[2]](https://www.researchgate.net/profile/Thomas-Helie/publication/241433373_Measures_and_Parameter_Estimation_of_Triodes_for_the_Real-Time_Simulation_of_a_Multi-Stage_Guitar_Preamplifier/links/5459e0e30cf2bccc4912d9ba/Measures-and-Parameter-Estimation-of-Triodes-for-the-Real-Time-Simulation-of-a-Multi-Stage-Guitar-Preamplifier.pdf?origin=publication_detail) that we currently use in Pentodes. Polynomial smoothing helps with stability. I've also noticed, that Koren model gives better fitness e.g:
![image](https://user-images.githubusercontent.com/19556976/160940883-b1f100e4-f0ce-4bd4-a1c6-1a1d22254a17.png)
vs
![image](https://user-images.githubusercontent.com/19556976/160940960-00f0149b-1902-466a-80fa-46d6ad5f1dee.png)
(images are from [this tool](https://federerer.github.io/tube-model-fitter/))
I've added additional parameters to the model to represent the new model variables. Unfortunately, getting correct values for all vacuum types will be difficult, as  grid current vs grid voltage plots are not common in old datasheets 😢