### PR TITLE
Fix for dBConverter throwing"InvalidCastException"

### DIFF
--- a/LiveSPICE/LiveSimulation.xaml
+++ b/LiveSPICE/LiveSimulation.xaml
@@ -95,7 +95,7 @@
                 <xctk:IntegerUpDown Value="{Binding Iterations, Delay=1000}" Minimum="1" Maximum="64" />
 
                 <Separator />
-                
+
                 <ls:ImageButton CommandImage="{x:Static ls:Commands.Simulate}" ImageHeight="16" />
             </ToolBar>
             <!-- View -->
@@ -121,6 +121,17 @@
                             <xcad:LayoutAnchorable x:Name="audio" Title="Audio" AutoHideWidth="240">
                                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                                     <StackPanel Orientation="Vertical">
+                                        <StackPanel.Resources>
+                                            <Style TargetType="{x:Type TextBox}">
+                                                <Style.Triggers>
+                                                    <Trigger Property="Validation.HasError" Value="true">
+                                                        <Setter Property="ToolTip"
+                                                                Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+                                                                Path=(Validation.Errors)/ErrorContent}" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Resources>
                                         <DockPanel Margin="5">
                                             <TextBlock DockPanel.Dock="Left" Width="40" 
                                                        Text="Input" FontWeight="Bold" VerticalAlignment="Center" />
@@ -128,7 +139,7 @@
                                                        Text="Gain: " 
                                                        TextAlignment="Right" VerticalAlignment="Center" />
                                             <TextBox DockPanel.Dock="Left" Width="50" 
-                                                     Text="{Binding InputGain, Converter={StaticResource dBConverter}, StringFormat={}{0:+#;-#;+0} dB}" 
+                                                     Text="{Binding InputGain, Converter={StaticResource dBConverter}, StringFormat={}{0:+#;-#;+0} dB, ValidatesOnExceptions=True}" 
                                                      TextAlignment="Left" VerticalAlignment="Center" />
                                             <Slider DockPanel.Dock="Right" 
                                                     Value="{Binding InputGain, Converter={StaticResource dBConverter}}" Minimum="-40" Maximum="40" />
@@ -160,7 +171,7 @@
                             </xcad:LayoutAnchorable>
                         </xcad:LayoutAnchorablePane>
                     </xcad:LayoutPanel>
-                    
+
                     <xcad:LayoutPanel Orientation="Vertical" DockWidth="*">
                         <xcad:LayoutDocumentPane DockHeight="*">
                             <!-- Schematic -->

--- a/LiveSPICE/Utils/dBConverter.cs
+++ b/LiveSPICE/Utils/dBConverter.cs
@@ -12,7 +12,11 @@ namespace LiveSPICE
         }
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return Math.Pow(10, System.Convert.ToDouble(value) / 20);
+            if (value is string s && double.TryParse(s, out var dbValue))
+            {
+                return Math.Pow(10, dbValue / 20);
+            }
+            return value;
         }
     }
 }


### PR DESCRIPTION
On current master, when you try manually input a value for "Input gain" or "Output gain" during the simulation an unhanled exception is thrown:
![image](https://user-images.githubusercontent.com/19556976/166259976-94714d04-f3cc-4ccb-ad66-e4d9ae6b039b.png)
This PR fixes it.
