### PR TITLE
Fix switch initial conditions

### DIFF
--- a/Circuit/Components/Switch.cs
+++ b/Circuit/Components/Switch.cs
@@ -52,7 +52,7 @@ namespace Circuit
         // resistances, capacitances, and inductances, multipled by 1000 or something like that. Just using
         // an absurdly huge value like 1e100 will ruin the precision of the numerical solvers.
         public static Expression OpenSwitchResistance = Variable.New("_OSR");
-        public static Arrow IncludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, 1e12);
+        public static Arrow IncludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, 1e12d);
         public static Arrow ExcludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, Real.Infinity);
 
         public override void Analyze(Analysis Mna)

--- a/Circuit/Components/Switch.cs
+++ b/Circuit/Components/Switch.cs
@@ -51,9 +51,9 @@ namespace Circuit
         // easy to determine a reasonable fake resistance. We should probably use the max of all component
         // resistances, capacitances, and inductances, multipled by 1000 or something like that. Just using
         // an absurdly huge value like 1e100 will ruin the precision of the numerical solvers.
-        public static Expression OpenSwitchResistance = Variable.New("_OSR");
-        public static Arrow IncludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, 1e12d);
-        public static Arrow ExcludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, Real.Infinity);
+        public static Expression OpenResistance = Variable.New("_OSR");
+        public static Arrow IncludeOpen = Arrow.New(OpenResistance, 1e12d);
+        public static Arrow ExcludeOpen = Arrow.New(OpenResistance, Real.Infinity);
 
         public override void Analyze(Analysis Mna)
         {
@@ -70,7 +70,7 @@ namespace Circuit
             {
                 // A truly unconnected throw terminal makes solving for initial conditions very difficult.
                 // Rather than fully disconnect the terminal, insert a fake resistor.
-                Resistor.Analyze(Mna, Name, Anode, Cathode, OpenSwitchResistance);
+                Resistor.Analyze(Mna, Name, Anode, Cathode, OpenResistance);
             }
         }
 

--- a/Circuit/Components/Switch.cs
+++ b/Circuit/Components/Switch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using ComputerAlgebra;
 
 namespace Circuit
 {
@@ -44,10 +45,33 @@ namespace Circuit
             Name = "S1";
         }
 
+        // This the value of resistors inserted into unconnected switches, which can be substituted to
+        // either be included or excluded in a circuit equation. We don't use a fake large resistance
+        // unconditionally because it could impact the performance of simulations, and it's not that
+        // easy to determine a reasonable fake resistance. We should probably use the max of all component
+        // resistances, capacitances, and inductances, multipled by 1000 or something like that. Just using
+        // an absurdly huge value like 1e100 will ruin the precision of the numerical solvers.
+        public static Expression OpenSwitchResistance = Variable.New("_OSR");
+        public static Arrow IncludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, 1e12);
+        public static Arrow ExcludeOpenSwitches = Arrow.New(SinglePoleSwitch.OpenSwitchResistance, Real.Infinity);
+
         public override void Analyze(Analysis Mna)
         {
-            if (0 <= position && position < Throws.Length)
-                Conductor.Analyze(Mna, Name, Common, Throws[Position]);
+            for (int i = 0; i < Throws.Length; ++i)
+                Analyze(Mna, Name, Common, Throws[i], i == Position);
+        }
+        public static void Analyze(Analysis Mna, string Name, Terminal Anode, Terminal Cathode, bool Closed)
+        {
+            if (Closed)
+            {
+                Conductor.Analyze(Mna, Name, Anode, Cathode);
+            }
+            else
+            {
+                // A truly unconnected throw terminal makes solving for initial conditions very difficult.
+                // Rather than fully disconnect the terminal, insert a fake resistor.
+                Resistor.Analyze(Mna, Name, Anode, Cathode, OpenSwitchResistance);
+            }
         }
 
         protected internal override void LayoutSymbol(SymbolLayout Sym)
@@ -116,8 +140,7 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            if (closed)
-                Conductor.Analyze(Mna, Name, Anode, Cathode);
+            SinglePoleSwitch.Analyze(Mna, Name, Anode, Cathode, Closed);
         }
 
         protected internal override void LayoutSymbol(SymbolLayout Sym)

--- a/Circuit/Simulation/Simulation.cs
+++ b/Circuit/Simulation/Simulation.cs
@@ -430,6 +430,15 @@ namespace Circuit
                     LinqExpr.ArrayAccess(Abi, LinqExpr.Constant(N)),
                     code.Compile(eqs[i][1])));
             }
+            // In case we have fewer equations than unknowns, we can avoid dumb failures to converge by just
+            // avoiding "uninitialized" memory left over in the buffer from previous solutions.
+            for (int i = M; i < N; ++i)
+            {
+                LinqExpr Abi = code.ReDeclInit<double[]>("Abi", LinqExpr.ArrayAccess(Ab, LinqExpr.Constant(i)));
+                code.Add(LinqExpr.Assign(
+                    LinqExpr.ArrayAccess(Abi, LinqExpr.Constant(N)), 
+                    LinqExpr.Constant(0.0)));
+            }
 
             // Gaussian elimination on this turd.
             code.Add(LinqExpr.Call(

--- a/Circuit/Simulation/TransientSolution.cs
+++ b/Circuit/Simulation/TransientSolution.cs
@@ -97,7 +97,7 @@ namespace Circuit
 
             SystemOfEquations dc = new SystemOfEquations(mna
                 // Derivatives, t, and T are zero in the steady state.
-                .Substitute(dy_dt.Select(i => Arrow.New(i, 0)).Append(Arrow.New(t, 0), Arrow.New(T, 0), SinglePoleSwitch.IncludeOpenSwitches))
+                .Substitute(dy_dt.Select(i => Arrow.New(i, 0)).Append(Arrow.New(t, 0), Arrow.New(T, 0), SinglePoleSwitch.IncludeOpen))
                 // Use the initial conditions from analysis.
                 .Substitute(Analysis.InitialConditions)
                 // Evaluate variables at t=0.
@@ -122,7 +122,7 @@ namespace Circuit
             // Transient analysis of the system.
             Log.WriteLine(MessageType.Info, "Performing transient analysis...");
 
-            SystemOfEquations system = new SystemOfEquations(mna.Substitute(SinglePoleSwitch.ExcludeOpenSwitches).OfType<Equal>(), dy_dt.Concat(y));
+            SystemOfEquations system = new SystemOfEquations(mna.Substitute(SinglePoleSwitch.ExcludeOpen).OfType<Equal>(), dy_dt.Concat(y));
 
             // Solve the diff eq for dy/dt and integrate the results.
             system.RowReduce(dy_dt);

--- a/Tests/Circuits/SP3T.schx
+++ b/Tests/Circuits/SP3T.schx
@@ -1,35 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Schematic Name="" Description="" PartNumber="">
+<Schematic Name="" PartNumber="">
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="-200,-50">
-    <Component _Type="Circuit.Input, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Name="V1" />
+    <Component _Type="Circuit.Input, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" V0dBFS="1 V" Name="V1" Description="Ideal voltage source representing an input port." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-2" Flip="false" Position="0,50">
-    <Component _Type="Circuit.Resistor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Resistance="1 kΩ" Name="R1" />
+    <Component _Type="Circuit.Resistor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Resistance="1 kΩ" Name="R1" Description="Standard resistor." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-1" Flip="false" Position="-50,0">
-    <Component _Type="Circuit.Capacitor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Capacitance="100 nF" Name="C1" />
+    <Component _Type="Circuit.Capacitor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Capacitance="100 nF" Name="C1" Description="Standard capacitor component" />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="0,130">
-    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Name="GND1" />
+    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND1" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-30,0" B="100,0" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,0" B="0,30" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,70" B="0,100" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,100" B="0,130" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="100,50">
-    <Component _Type="Circuit.Speaker, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Impedance="1 MΩ" Name="S1" />
+    <Component _Type="Circuit.Speaker, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" V0dBFS="1 V" Impedance="1 MΩ" Name="S1" Description="Ideal speaker." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-5" Flip="false" Position="-50,-200">
-    <Component _Type="Circuit.Resistor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Resistance="1 kΩ" Name="R2" />
+    <Component _Type="Circuit.Resistor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Resistance="1 kΩ" Name="R2" Description="Standard resistor." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-2" Flip="false" Position="0,-150">
-    <Component _Type="Circuit.Capacitor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Capacitance="100 nF" Name="C2" />
+    <Component _Type="Circuit.Capacitor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Capacitance="100 nF" Name="C2" Description="Standard capacitor component" />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-100,-200" B="-70,-200" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,-200" B="0,-170" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,-130" B="0,-100" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="0,-70">
-    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Name="GND2" />
+    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND2" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,-100" B="0,-70" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-30,-200" B="0,-200" />
@@ -38,26 +38,34 @@
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="100,0" B="100,30" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="100,70" B="100,130" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="100,130">
-    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Name="GND3" />
+    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND3" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-130,-120" B="-100,-120" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-100,-200" B="-100,-120" />
-  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-130,-80" B="-100,-80" />
-  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-100,-80" B="-100,0" />
+  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-130,-100" B="-100,-100" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-100,0" B="-70,0" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-200,-100" B="-200,-70" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-200,-100" B="-170,-100" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="-200,0">
-    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Name="GND4" />
+    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND4" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-200,-30" B="-200,0" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="10,-240">
-    <Component _Type="Circuit.Label, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Text="Lowpass" Subtext="" Name="_1" />
+    <Component _Type="Circuit.Label, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Text="Lowpass" Subtext="" Name="_1" Description="Displays a text label on a schematic." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-4" Flip="false" Position="-90,70">
-    <Component _Type="Circuit.Label, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Text="Highpass" Subtext="" Name="_2" />
+    <Component _Type="Circuit.Label, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Text="Highpass" Subtext="" Name="_2" Description="Displays a text label on a schematic." />
   </Element>
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-1" Flip="false" Position="-150,-100">
-    <Component _Type="Circuit.SP3T, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Position="0" Name="S2" />
+    <Component _Type="Circuit.SP3T, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Position="0" Group="" Name="S2" Description="single pole triple-throw switch." />
+  </Element>
+  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-100,-100" B="-100,0" />
+  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-130,-80" B="-130,-60" />
+  <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="-130,-40">
+    <Component _Type="Circuit.Resistor, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Resistance="100 kΩ" Name="R3" Description="Standard resistor." />
+  </Element>
+  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-130,-20" B="-130,0" />
+  <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="-130,0">
+    <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND5" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
 </Schematic>

--- a/Tests/Examples/Fender 5e3.schx
+++ b/Tests/Examples/Fender 5e3.schx
@@ -75,7 +75,6 @@
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="30,-270" B="50,-270" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="30,-50" B="50,-50" />
-  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-50,-90" B="-40,-90" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-50,-170" B="-30,-170" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-30,-170" B="-20,-170" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-1" Flip="false" Position="0,-130">
@@ -112,7 +111,6 @@
     <Component _Type="Circuit.Ground, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" WireName="GND" Name="GND6" Description="Nodes with the same name are connected as if they were connected by a continuous wire." />
   </Element>
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="170,-190" B="170,-170" />
-  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="0,-110" B="20,-110" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="160,-50" B="180,-50" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="160,-270" B="180,-270" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="-1" Flip="false" Position="130,-50">
@@ -172,7 +170,6 @@
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="150,-270" B="160,-270" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="90,-50" B="110,-50" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="150,-50" B="160,-50" />
-  <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="20,-130" B="30,-130" />
   <Element Type="Circuit.Wire, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" A="-200,-80" B="-160,-80" />
   <Element Type="Circuit.Symbol, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Rotation="0" Flip="false" Position="-730,-120">
     <Component _Type="Circuit.Input, Circuit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" V0dBFS="1" Name="V3" Description="Ideal voltage source representing an input port." />


### PR DESCRIPTION
@Federerer I am curious to see what you think of this solution to #148. It adds a fake symbolic resistor for open switch circuits that has a large but finite value when solving for initial conditions, and is actually infinity when running the simulation.

This seems to fix all cases of initial conditions failing due to switches (two example circuits, plus your reproducer from #148).

I think this solution is quite a hack, and exposes some really weird behavior in the solver that needs a fix that seems like nonsense.

I am particularly curious if this eliminates the need for your random reordering of components to improve stability. It's possible that the extra stability is only needed because the simulation is starting so far away from the normal operating point...

