### PR TITLE
Update VST to use AudioPlugSharp NuGet packages

### DIFF
--- a/LiveSPICEVst/LiveSPICEVst.csproj
+++ b/LiveSPICEVst/LiveSPICEVst.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>LiveSPICEVst</AssemblyName>
     <Product>LiveSPICEVst</Product>
@@ -15,16 +15,6 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AudioPlugSharp, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\AudioPlugSharp\x64\AudioPlugSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="AudioPlugSharpWPF, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\AudioPlugSharp\x64\AudioPlugSharpWPF.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Resource Include="Images\MetalAlpha.png" />
   </ItemGroup>
   <ItemGroup>
@@ -34,12 +24,9 @@
     <ProjectReference Include="..\Util\Util.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AudioPlugSharp" Version="0.5.0" />
+    <PackageReference Include="AudioPlugSharpWPF" Version="0.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <PropertyGroup />
-  <PropertyGroup />
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy $(SolutionDir)AudioPlugSharp\x64\AudioPlugSharpVst.vst3 $(TargetDir)$(TargetName)Bridge.vst3&#xD;&#xA;copy $(SolutionDir)AudioPlugSharp\x64\wpf.runtimeconfig.json $(TargetDir)$(TargetName)Bridge.runtimeconfig.json&#xD;&#xA;copy $(SolutionDir)AudioPlugSharp\x64\AudioPlugSharpVst.deps.json $(TargetDir)$(TargetName)Bridge.deps.json&#xD;&#xA;copy $(SolutionDir)AudioPlugSharp\x64\Ijwhost.dll $(TargetDir)" />
-  </Target>
 </Project>

--- a/MockVst/DummyHost.cs
+++ b/MockVst/DummyHost.cs
@@ -14,5 +14,46 @@ namespace MockVst
         public UInt32 MaxAudioBufferSize { get { return 64; } }
         public double BPM { get { return 120; } }
         public double SamplePosition { get { return 0; } }
+
+        public uint CurrentAudioBufferSize => 256;
+        public long CurrentProjectSample => 0;
+        public bool IsPlaying => true;
+
+        public void BeginEdit(int parameter)
+        {
+        }
+
+        public void EndEdit(int parameter)
+        {
+        }
+
+        public void PerformEdit(int parameter, double normalizedValue)
+        {
+        }
+
+        public void ProcessAllEvents()
+        {
+        }
+
+        public int ProcessEvents()
+        {
+            return 0;
+        }
+
+        public void SendCC(int channel, int ccNumber, int ccValue, int sampleOffset)
+        {
+        }
+
+        public void SendNoteOff(int channel, int noteNumber, float velocity, int sampleOffset)
+        {
+        }
+
+        public void SendNoteOn(int channel, int noteNumber, float velocity, int sampleOffset)
+        {
+        }
+
+        public void SendPolyPressure(int channel, int noteNumber, float pressure, int sampleOffset)
+        {
+        }
     }
 }

--- a/MockVst/MockVst.csproj
+++ b/MockVst/MockVst.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>LiveSPICEApp</AssemblyName>
     <Product>LiveSPICEApp</Product>
@@ -16,15 +16,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="AudioPlugSharp, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\AudioPlugSharp\x64\AudioPlugSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="AudioPlugSharpWPF, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\AudioPlugSharp\x64\AudioPlugSharpWPF.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -16,11 +16,3 @@ To clone the LiveSPICE repo, run the following commands:
 ```bash
 git clone --recursive https://github.com/dsharlet/LiveSPICE.git LiveSPICE
 ```
-
-The VST plugin depends on https://github.com/mikeoliphant/AudioPlugSharp
-
-To enable building the VST plugin, do the following from a shell in the LiveSPICE root folder:
-```bash
-curl https://github.com/mikeoliphant/AudioPlugSharp/releases/download/v0.2/AudioPlugSharp.zip -O AudioPlugSharp.zip
-powershell -command "Expand-Archive -Force AudioPlugSharp.zip"
-```


### PR DESCRIPTION
This PR updates the VST to use the AudioPlugSharp NuGet packages, making out-of-the-box compilation much easier.