### PR TITLE
Github actions for builds and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,27 +31,38 @@ jobs:
       - name: Build LiveSPICE
         shell: pwsh
         run: |
-          $workdir = Get-Location
-
           cd LiveSPICE
           dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
-      - name: Package LiveSPICE
+      - name: Build LiveSPICEVst
+        shell: pwsh
+        run: |
+          cd LiveSPICEVst
+          dotnet publish -c Release --framework net6.0-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
+      - name: Package LiveSPICE Setup version
+        shell: pwsh
+        run: iscc LiveSPICESetup.iss
+      - name: Package LiveSPICE Portable version
         shell: pwsh
         run: |
           $workdir = Get-Location
 
-          # Build InnoSetup installer
-          iscc LiveSPICESetup.iss
-
-          # Package portable tarball
-          cd LiveSPICE
+          cd $workdir\LiveSPICE
           Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination bin\Release\net50-windows\Components\ -Force -PassThru
-          dir bin\Release\net50-windows\
-          dir bin\Release\net50-windows\Components\
           cd bin\Release
 
           ren net50-windows LiveSPICE
           Compress-Archive -Path LiveSPICE -DestinationPath $workdir\LiveSPICE-${{ github.ref_name }}.zip
+
+          cd $workdir\LiveSPICEVst
+          New-Item -Name "LiveSPICEVst" -ItemType "directory"
+          New-Item -Name "LiveSPICEVst\Components" -ItemType "directory"
+
+          Copy-Item bin\Release\net6.0-windows\LiveSPICEVstBridge.vst3 -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem bin\Release\net6.0-windows\ -Filter *.dll | Copy-Item -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem bin\Release\net6.0-windows\ -Filter *.json | Copy-Item -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination LiveSPICEVst\Components\ -Force -PassThru
+
+          Compress-Archive -Path LiveSPICEVst -DestinationPath $workdir\LiveSPICEVst-${{ github.ref_name }}.zip
       - name: Publish LiveSPICE artifacts
         uses: softprops/action-gh-release@v1
         env:
@@ -60,3 +71,4 @@ jobs:
           files: |
             LiveSPICESetup.exe
             LiveSPICE-${{ github.ref_name }}.zip
+            LiveSPICEVst-${{ github.ref_name }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+on:
+  release:
+    types: [created]
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+
+jobs:
+  release:
+    name: Release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v2
+        with:
+          # https://dotnet.microsoft.com/en-us/download/dotnet
+          dotnet-version: '6.0.x'
+      - name: Collect metadata
+        id: METADATA
+        shell: pwsh
+        run: |
+          $commit = git rev-parse HEAD
+          $commit_short = $commit.SubString(0, 7)
+
+          echo "commit=$commit" >> $env:GITHUB_OUTPUT
+          echo "commit_short=$commit_short" >> $env:GITHUB_OUTPUT
+          echo "build_id=$commit_short-${{ github.run_id }}"  >> $env:GITHUB_OUTPUT
+      - name: Build LiveSPICE
+        shell: pwsh
+        run: |
+          $workdir = Get-Location
+
+          cd LiveSPICE
+          dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
+      - name: Package LiveSPICE
+        shell: pwsh
+        run: |
+          $workdir = Get-Location
+
+          # Build InnoSetup installer
+          iscc LiveSPICESetup.iss
+
+          # Package portable tarball
+          cd LiveSPICE
+          Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination bin\Release\net50-windows\Components\ -Force -PassThru
+          dir bin\Release\net50-windows\
+          dir bin\Release\net50-windows\Components\
+          cd bin\Release
+
+          ren net50-windows LiveSPICE
+          Compress-Archive -Path LiveSPICE -DestinationPath $workdir\LiveSPICE-${{ github.ref_name }}.zip
+      - name: Publish LiveSPICE artifacts
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            LiveSPICESetup.exe
+            LiveSPICE-${{ github.ref_name }}.zip

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -30,6 +30,7 @@ jobs:
           echo "commit=$commit" >> $env:GITHUB_OUTPUT
           echo "commit_short=$commit_short" >> $env:GITHUB_OUTPUT
           echo "build_id=$commit_short-${{ github.run_id }}"  >> $env:GITHUB_OUTPUT
+
       - name: Snapshot LiveSPICE
         shell: pwsh
         run: |
@@ -39,14 +40,35 @@ jobs:
           dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
 
           Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination bin\Release\net50-windows\Components\ -Force -PassThru
-          dir bin\Release\net50-windows\
-          dir bin\Release\net50-windows\Components\
           cd bin\Release
 
           ren net50-windows LiveSPICE
           Compress-Archive -Path LiveSPICE -DestinationPath $workdir\LiveSPICE.zip
-      - name: Publish snapshot artifact
+      - name: Publish LiveSPICE snapshot
         uses: actions/upload-artifact@v3
         with:
           path: LiveSPICE.zip
           name: LiveSPICE-${{ steps.METADATA.outputs.build_id }}.zip
+
+      - name: Snapshot LiveSPICEVst
+        shell: pwsh
+        run: |
+          $workdir = Get-Location
+
+          cd LiveSPICEVst
+          dotnet publish -c Release --framework net6.0-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
+
+          New-Item -Name "LiveSPICEVst" -ItemType "directory"
+          New-Item -Name "LiveSPICEVst\Components" -ItemType "directory"
+
+          Copy-Item bin\Release\net6.0-windows\LiveSPICEVstBridge.vst3 -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem bin\Release\net6.0-windows\ -Filter *.dll | Copy-Item -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem bin\Release\net6.0-windows\ -Filter *.json | Copy-Item -Destination LiveSPICEVst\ -Force -PassThru
+          Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination LiveSPICEVst\Components\ -Force -PassThru
+
+          Compress-Archive -Path LiveSPICEVst -DestinationPath $workdir\LiveSPICEVst.zip
+      - name: Publish LiveSPICEVst snapshot
+        uses: actions/upload-artifact@v3
+        with:
+          path: LiveSPICEVst.zip
+          name: LiveSPICEVst-${{ steps.METADATA.outputs.build_id }}.zip

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,52 @@
+name: Snapshot
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+
+jobs:
+  snapshot:
+    name: Snapshot
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v2
+        with:
+          # https://dotnet.microsoft.com/en-us/download/dotnet
+          dotnet-version: '6.0.x'
+      - name: Collect metadata
+        id: METADATA
+        shell: pwsh
+        run: |
+          $commit = git rev-parse HEAD
+          $commit_short = $commit.SubString(0, 7)
+
+          echo "commit=$commit" >> $env:GITHUB_OUTPUT
+          echo "commit_short=$commit_short" >> $env:GITHUB_OUTPUT
+          echo "build_id=$commit_short-${{ github.run_id }}"  >> $env:GITHUB_OUTPUT
+      - name: Snapshot LiveSPICE
+        shell: pwsh
+        run: |
+          $workdir = Get-Location
+
+          cd LiveSPICE
+          dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
+
+          Get-ChildItem $workdir\Circuit\Components\ -Filter *.xml | Copy-Item -Destination bin\Release\net50-windows\Components\ -Force -PassThru
+          dir bin\Release\net50-windows\
+          dir bin\Release\net50-windows\Components\
+          cd bin\Release
+
+          ren net50-windows LiveSPICE
+          Compress-Archive -Path LiveSPICE -DestinationPath $workdir\LiveSPICE.zip
+      - name: Publish snapshot artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: LiveSPICE.zip
+          name: LiveSPICE-${{ steps.METADATA.outputs.build_id }}.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+on:
+- push
+- pull_request
+- workflow_dispatch
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+
+jobs:
+  test:
+    name: Test
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v2
+        with:
+          # https://dotnet.microsoft.com/en-us/download/dotnet
+          dotnet-version: '6.0.x'
+      - name: Test LiveSPICE build
+        shell: pwsh
+        working-directory: LiveSPICE
+        run: dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,7 @@ jobs:
         shell: pwsh
         working-directory: LiveSPICE
         run: dotnet publish -c Release --framework net50-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false
+      - name: Test LiveSPICEVst build
+        shell: pwsh
+        working-directory: LiveSPICEVst
+        run: dotnet publish -c Release --framework net6.0-windows /p:DebugType=None /p:UseSharedCompilation=false  /p:UseRazorBuildServer=false

--- a/LiveSPICESetup.iss
+++ b/LiveSPICESetup.iss
@@ -18,7 +18,7 @@ OutputDir=.
 
 [Components]
 Name: "main"; Description: "LiveSPICE"; Types: full compact custom; Flags: fixed
-Name: "vst"; Description: "VST Plugin"; Types: full custom
+; Name: "vst"; Description: "VST Plugin"; Types: full custom
 
 [Files]
 Source: "LiveSPICE\bin\Release\net50-windows\LiveSPICE.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -28,9 +28,9 @@ Source: "Circuit\Components\*.xml"; DestDir: "{app}\Components"
 Source: "Circuit\Components\Readme.txt"; DestDir: "{userdocs}\LiveSPICE\Components"
 Source: "Tests\Examples\*.schx"; DestDir: "{userdocs}\LiveSPICE\Examples"
 
-Source: "LiveSPICEVst\bin\Release\net5.0-windows\LiveSPICEVstBridge.vst3"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
-Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.dll"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
-Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.json"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+; Source: "LiveSPICEVst\bin\Release\net5.0-windows\LiveSPICEVstBridge.vst3"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+; Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.dll"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+; Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.json"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
 
 [Run]
 Filename: "{app}\LiveSPICE.exe"; Description: "Run LiveSPICE."; Flags: postinstall nowait

--- a/LiveSPICESetup.iss
+++ b/LiveSPICESetup.iss
@@ -18,7 +18,7 @@ OutputDir=.
 
 [Components]
 Name: "main"; Description: "LiveSPICE"; Types: full compact custom; Flags: fixed
-; Name: "vst"; Description: "VST Plugin"; Types: full custom
+Name: "vst"; Description: "VST Plugin"; Types: full custom
 
 [Files]
 Source: "LiveSPICE\bin\Release\net50-windows\LiveSPICE.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -28,9 +28,9 @@ Source: "Circuit\Components\*.xml"; DestDir: "{app}\Components"
 Source: "Circuit\Components\Readme.txt"; DestDir: "{userdocs}\LiveSPICE\Components"
 Source: "Tests\Examples\*.schx"; DestDir: "{userdocs}\LiveSPICE\Examples"
 
-; Source: "LiveSPICEVst\bin\Release\net5.0-windows\LiveSPICEVstBridge.vst3"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
-; Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.dll"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
-; Source: "LiveSPICEVst\bin\Release\net5.0-windows\*.json"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+Source: "LiveSPICEVst\bin\Release\net6.0-windows\LiveSPICEVstBridge.vst3"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+Source: "LiveSPICEVst\bin\Release\net6.0-windows\*.dll"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
+Source: "LiveSPICEVst\bin\Release\net6.0-windows\*.json"; DestDir: "C:\Program Files\Common Files\VST3\LiveSPICE"; Flags: ignoreversion; Components: vst
 
 [Run]
 Filename: "{app}\LiveSPICE.exe"; Description: "Run LiveSPICE."; Flags: postinstall nowait


### PR DESCRIPTION
This PR addresses the issue #172:
- Example of test: https://github.com/mdouchement/LiveSPICE/actions/runs/4747535761
- Example of snapshot: https://github.com/mdouchement/LiveSPICE/actions/runs/4747537811
- Example of release: https://github.com/mdouchement/LiveSPICE/releases/tag/v0.14-testouille
  - The action is trigged when a new release is created in Github

~~VST part is omitted/disabled due to my lack of .NET knowledge but it can be fixed in another PR by someone else.~~