### PR TITLE
Enable running release manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   release:
     types: [created]
 env:


### PR DESCRIPTION
Embarrassingly, I can't figure out how to run the release workflow. I think it might run automatically when I make a release... but I'm not sure? I wanted to test the release before making it, so I'd rather have a way to run it manually too.

Trying to address #172.