### PR TITLE
Revert "Enable running release manually"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 on:
-  workflow_dispatch:
   release:
     types: [created]
 env:


### PR DESCRIPTION
Reverts dsharlet/LiveSPICE#175

This workflow can't run manually without a tag anyways.