### PR TITLE
Drop library targets back to netstandard2.0

### DIFF
--- a/Asio/Asio.csproj
+++ b/Asio/Asio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyName>Asio</AssemblyName>
     <Product>Asio</Product>

--- a/Audio/Audio.csproj
+++ b/Audio/Audio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>Audio</AssemblyName>
     <Product>Audio</Product>

--- a/Circuit/Circuit.csproj
+++ b/Circuit/Circuit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>Circuit</AssemblyName>
     <Product>Circuit</Product>

--- a/Tests/Properties/launchSettings.json
+++ b/Tests/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tests": {
       "commandName": "Project",
-      "commandLineArgs": "benchmark Examples\\*.schx --sampleRate 44100",
+      "commandLineArgs": "benchmark Examples\\*.schx --sampleRate 44100"
     }
   }
 }

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>Util</AssemblyName>
     <Product>Util</Product>

--- a/WaveAudio/WaveAudio.csproj
+++ b/WaveAudio/WaveAudio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>WaveAudio</AssemblyName>
     <Product>WaveAudio</Product>


### PR DESCRIPTION
@Federerer let me know if you think this look right. I think even command line apps should target net6.0-windows due to significant performance improvements. (I ruled out the recent `CompareTo` fix as the cause of this improvement)