### PR TITLE
Optimize Schematic.Deserialize, a lot

### DIFF
--- a/Circuit/Schematic/Element.cs
+++ b/Circuit/Schematic/Element.cs
@@ -38,10 +38,10 @@ namespace Circuit
         public virtual bool Intersects(Coord x1, Coord x2)
         {
             Coord l = LowerBound;
-            if (l.x >= x2.x || l.y >= x2.y) return false;
+            if (l.x > x2.x || l.y > x2.y) return false;
 
             Coord u = UpperBound;
-            if (u.x <= x1.x || u.y <= x1.y) return false;
+            if (u.x < x1.x || u.y < x1.y) return false;
             return true;
         }
 

--- a/Circuit/Schematic/Schematic.cs
+++ b/Circuit/Schematic/Schematic.cs
@@ -186,6 +186,10 @@ namespace Circuit
             {
                 // If the removed element is a wire, we might have to split the node it was a part of.
                 RebuildNode(wire.Node);
+
+                // Reconnect any terminals connected to this wire's node, in case they are no longer connected.
+                // We could be more precise here, but it probably doesn't matter when removing elements.
+                ReconnectAllTerminals();
             }
 
             foreach (Terminal j in e.Element.Terminals)

--- a/Circuit/Schematic/Schematic.cs
+++ b/Circuit/Schematic/Schematic.cs
@@ -213,22 +213,26 @@ namespace Circuit
             UpdateTerminals(of);
         }
 
+        private IEnumerable<Wire> ConnectedTo(IEnumerable<Wire> Wires, Wire Target, HashSet<Wire> visited)
+        {
+            foreach (Wire i in Wires.Where(j => !visited.Contains(j)))
+            {
+                if (i.IsConnectedTo(Target))
+                {
+                    visited.Add(i);
+                    yield return i;
+                    foreach (Wire j in ConnectedTo(Wires, i, visited))
+                        yield return j;
+                }
+            }
+        }
+
         // Wires was a single node but it is now two. Break it into two sets of nodes
         // and return the one containing Target.
         private IEnumerable<Wire> ConnectedTo(IEnumerable<Wire> Wires, Wire Target)
         {
-            // Repeatedly search for connections with the target.
-            IEnumerable<Wire> connected = new Wire[] { Target };
-            int count = connected.Count();
-            while (true)
-            {
-                connected = Wires.Where(i => connected.Any(j => i.IsConnectedTo(j))).ToArray();
-                if (connected.Count() == count)
-                    break;
-                count = connected.Count();
-            }
-
-            return connected;
+            HashSet<Wire> visited = new HashSet<Wire>();
+            return ConnectedTo(Wires.Buffer(), Target, visited);
         }
 
         // Merge all of the nodes contained in wires to one.

--- a/Circuit/Schematic/Schematic.cs
+++ b/Circuit/Schematic/Schematic.cs
@@ -163,12 +163,17 @@ namespace Circuit
         /// <returns></returns>
         public Node NodeAt(Coord x, Wire Self)
         {
-            IEnumerable<Wire> wires = Wires;
-            if (Self != null)
-                wires = wires.Except(Self);
-
-            Wire w = wires.FirstOrDefault(i => i.IsConnectedTo(x));
-            return w?.Node;
+            foreach (Element e in elements)
+            {
+                if (e is Wire w)
+                {
+                    if (ReferenceEquals(w, Self))
+                        continue;
+                    if (w.IsConnectedTo(x))
+                        return w.Node;
+                }
+            }
+            return null;
         }
         public Node NodeAt(Coord x) { return NodeAt(x, null); }
 
@@ -276,7 +281,8 @@ namespace Circuit
             foreach (Wire i in Wires.Where(j => j.Node != n))
             {
                 i.Node = n;
-                UpdateTerminals(i);
+                foreach (Terminal j in i.Terminals)
+                    Connect(j, n);
             }
 
             // Everything connected to a node in nodes should now be connected to n.

--- a/Circuit/Schematic/Schematic.cs
+++ b/Circuit/Schematic/Schematic.cs
@@ -217,22 +217,19 @@ namespace Circuit
                 {
                     Node n = NodeAt(of.MapTerminal(i));
 
-                    if (n != i.ConnectedTo)
-                    {
-                        i.ConnectTo(n);
-                        // If this terminal is a named wire, the nodes need to be rebuilt.
+                    // If this terminal is a named wire, the node needs to be rebuilt.
+                    if (i.ConnectTo(n))
                         if (i.Owner is NamedWire && n != null)
                             RebuildNode(n);
-                    }
                 }
             }
         }
 
         private IEnumerable<Wire> ConnectedTo(IEnumerable<Wire> Wires, Wire Target, HashSet<Wire> visited)
         {
-            foreach (Wire i in Wires.Where(j => !visited.Contains(j)))
+            foreach (Wire i in Wires)
             {
-                if (i.IsConnectedTo(Target))
+                if (!visited.Contains(i) && i.IsConnectedTo(Target))
                 {
                     visited.Add(i);
                     yield return i;

--- a/Circuit/Schematic/Schematic.cs
+++ b/Circuit/Schematic/Schematic.cs
@@ -185,11 +185,11 @@ namespace Circuit
             }
             else if (e.Element is Wire wire)
             {
-                // Reconnect any terminals connected to this wire's node, in case they are no longer connected.
-                ReconnectAllTerminals(wire.Node.Connected.Select(i => (Element)i.Owner.Tag).ToArray());
-
                 // If the removed element is a wire, we might have to split the node it was a part of.
                 RebuildNode(wire.Node);
+
+                // Reconnect any terminals connected to this wire's node, in case they are no longer connected.
+                ReconnectAllTerminals(wire.Node.Connected.Select(i => (Element)i.Owner.Tag).ToArray());
             }
 
             foreach (Terminal j in e.Element.Terminals)
@@ -209,12 +209,12 @@ namespace Circuit
             Element of = (Element)sender;
             if (of is Wire wire)
             {
+                RebuildNode(wire.Node);
+
                 // Reconnect all the elements connected to this wire's node. This will disconnect any newly
                 // disconnected nodes.
                 ReconnectAllTerminals(wire.Node.Connected.Select(i => (Element)i.Owner.Tag).ToArray());
-
-                RebuildNode(wire.Node);
-
+                
                 // Now reconnect all terminals in the bounding box of this wire.
                 ReconnectAllTerminals(Elements.Where(i => i.Intersects(wire.LowerBound, wire.UpperBound)));
             }
@@ -322,7 +322,7 @@ namespace Circuit
         {
             HashSet<Wire> wires = new HashSet<Wire>();
             foreach (Wire i in Wires)
-                if (Nodes == null || Nodes.Contains(i.Node))
+                if (Nodes == null || i.Node == null || Nodes.Contains(i.Node))
                     wires.Add(i);
             while (!wires.Empty())
             {

--- a/Circuit/Terminal.cs
+++ b/Circuit/Terminal.cs
@@ -44,10 +44,11 @@ namespace Circuit
         /// Connect this terminal to the node.
         /// </summary>
         /// <param name="n"></param>
-        public void ConnectTo(Node N)
+        /// <returns>true if the connection was changed, false if not.</returns>
+        public bool ConnectTo(Node N)
         {
             if (connectedTo == N)
-                return;
+                return false;
 
             if (connectedTo != null)
                 connectedTo.Disconnect(this);
@@ -56,6 +57,7 @@ namespace Circuit
                 connectedTo.Connect(this);
 
             foreach (EventHandler i in connectionChanged) i(this, null);
+            return true;
         }
 
         private List<EventHandler> connectionChanged = new List<EventHandler>();

--- a/LiveSPICE/Controls/Editor/WireTool.cs
+++ b/LiveSPICE/Controls/Editor/WireTool.cs
@@ -62,8 +62,11 @@ namespace LiveSPICE
         {
             ((PathGeometry)path.Data).Clear();
             path.Visibility = Visibility.Hidden;
-            Editor.AddWire(Editor.FindWirePath(mouse));
-            mouse = null;
+            if (mouse != null)
+            {
+                Editor.AddWire(Editor.FindWirePath(mouse));
+                mouse = null;
+            }
 
             if ((Keyboard.Modifiers & ModifierKeys.Control) == 0)
                 Target.Tool = new SelectionTool(Editor);


### PR DESCRIPTION
This may work around the issue raised in #187. `Schematic.Deserialize` should be orders of magnitude faster with this branch.

The problem is when deserializing a circuit, the components and wires would be added as if they were added manually in the UI, rebuilding the nodes one at a time. The `ConnectedTo` algorithm was also quadratic. So I think the old behavior was two quadratic algorithms nested inside each other. How embarrassing :)