### PR TITLE
Remove iterations parameter

### DIFF
--- a/Circuit/Simulation/Simulation.cs
+++ b/Circuit/Simulation/Simulation.cs
@@ -69,17 +69,11 @@ namespace Circuit
             set { solution = value; InvalidateProcess(); }
         }
 
-        private int oversample = 8;
+        private int oversample = 2;
         /// <summary>
         /// Oversampling factor for this simulation.
         /// </summary>
         public int Oversample { get { return oversample; } set { oversample = value; InvalidateProcess(); } }
-
-        private int iterations = 8;
-        /// <summary>
-        /// Maximum number of iterations allowed for the simulation to converge.
-        /// </summary>
-        public int Iterations { get { return iterations; } set { iterations = value; InvalidateProcess(); } }
 
         /// <summary>
         /// The sampling rate of this simulation, the sampling rate of the transient solution divided by the oversampling factor.
@@ -313,7 +307,12 @@ namespace Circuit
                                     code.DeclInit(i.Left, i.Right);
 
                                 // int it = iterations
-                                LinqExpr it = code.ReDeclInit<int>("it", Iterations);
+                                // This used to be a parameter, defaulted to 8. Experiments seem to show that
+                                // it basically never makes sense to stop iterating at a limit. This sort of
+                                // makes sense, because stopping iteration early suggests that the initial guess
+                                // for the next sample will be worse. So, we're just going to use a very large
+                                // number of iterations just to avoid getting stuck forever.
+                                LinqExpr it = code.ReDeclInit<int>("it", 128);
                                 // do { ... --it } while(it > 0)
                                 code.DoWhile((Break) =>
                                 {

--- a/LiveSPICE/LiveSimulation.xaml
+++ b/LiveSPICE/LiveSimulation.xaml
@@ -91,9 +91,6 @@
                     <ComboBoxItem>16</ComboBoxItem>
                 </ComboBox>
 
-                <TextBlock Text="Iterations:" Margin="5, 0, 2, 0" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                <xctk:IntegerUpDown Value="{Binding Iterations, Delay=1000}" Minimum="1" Maximum="64" />
-
                 <Separator />
                 
                 <ls:ImageButton CommandImage="{x:Static ls:Commands.Simulate}" ImageHeight="16" />

--- a/LiveSPICE/LiveSimulation.xaml.cs
+++ b/LiveSPICE/LiveSimulation.xaml.cs
@@ -27,7 +27,7 @@ namespace LiveSPICE
         public Log Log { get { return (Log)log.Content; } }
         public Scope Scope { get { return (Scope)scope.Content; } }
 
-        protected int oversample = 8;
+        protected int oversample = 2;
         /// <summary>
         /// Simulation oversampling rate.
         /// </summary>
@@ -35,16 +35,6 @@ namespace LiveSPICE
         {
             get { return oversample; }
             set { oversample = Math.Max(1, value); RebuildSolution(); NotifyChanged(nameof(Oversample)); }
-        }
-
-        protected int iterations = 8;
-        /// <summary>
-        /// Max iterations for numerical algorithms.
-        /// </summary>
-        public int Iterations
-        {
-            get { return iterations; }
-            set { iterations = Math.Max(1, value); RebuildSolution(); NotifyChanged(nameof(Iterations)); }
         }
 
         private double inputGain = 1.0;
@@ -304,7 +294,6 @@ namespace LiveSPICE
                             Input = inputs.Keys.ToArray(),
                             Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
                             Oversample = Oversample,
-                            Iterations = Iterations,
                         };
                     }
                     catch (Exception Ex)
@@ -337,7 +326,6 @@ namespace LiveSPICE
                                 Input = inputs.Keys.ToArray(),
                                 Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
                                 Oversample = Oversample,
-                                Iterations = Iterations,
                             };
                         }
                         else

--- a/LiveSPICEVst/EditorView.xaml
+++ b/LiveSPICEVst/EditorView.xaml
@@ -37,16 +37,6 @@
                     <ComboBoxItem>4</ComboBoxItem>
                     <ComboBoxItem>8</ComboBoxItem>
                 </ComboBox>
-                <TextBlock>Iterations:</TextBlock>
-                <ComboBox x:Name="IterationsComboBox" SelectionChanged="IterationsComboBox_SelectionChanged">
-                    <ComboBoxItem>1</ComboBoxItem>
-                    <ComboBoxItem>2</ComboBoxItem>
-                    <ComboBoxItem>4</ComboBoxItem>
-                    <ComboBoxItem>8</ComboBoxItem>
-                    <ComboBoxItem>16</ComboBoxItem>
-                    <ComboBoxItem>32</ComboBoxItem>
-                    <ComboBoxItem>64</ComboBoxItem>
-                </ComboBox>
             </StackPanel>
             <local:SimulationInterface DataContext="{Binding SimulationProcessor}" />
         </DockPanel>

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -45,16 +45,6 @@ namespace LiveSPICEVst
                     break;
                 }
             }
-
-            for (int i = 0; i < IterationsComboBox.Items.Count; i++)
-            {
-                if (int.Parse((IterationsComboBox.Items[i] as ComboBoxItem).Content as string) == Plugin.SimulationProcessor.Iterations)
-                {
-                    IterationsComboBox.SelectedIndex = i;
-
-                    break;
-                }
-            }
         }
 
         private void OversampleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -62,13 +52,6 @@ namespace LiveSPICEVst
             ComboBox combo = sender as ComboBox;
 
             Plugin.SimulationProcessor.Oversample = int.Parse((combo.SelectedItem as ComboBoxItem).Content as string);
-        }
-
-        private void IterationsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            ComboBox combo = sender as ComboBox;
-
-            Plugin.SimulationProcessor.Iterations = int.Parse((combo.SelectedItem as ComboBoxItem).Content as string);
         }
 
         private void LoadCircuitButton_Click(object sender, RoutedEventArgs e)

--- a/LiveSPICEVst/LiveSPICEPlugin.cs
+++ b/LiveSPICEVst/LiveSPICEPlugin.cs
@@ -83,7 +83,6 @@ namespace LiveSPICEVst
             {
                 SchematicPath = SimulationProcessor.SchematicPath,
                 OverSample = SimulationProcessor.Oversample,
-                Iterations = SimulationProcessor.Iterations
             };
 
             foreach (var wrapper in SimulationProcessor.InteractiveComponents)
@@ -142,7 +141,6 @@ namespace LiveSPICEVst
                     }
 
                     SimulationProcessor.Oversample = programParameters.OverSample;
-                    SimulationProcessor.Iterations = programParameters.Iterations;
 
                     foreach (VSTProgramControlParameter controlParameter in programParameters.ControlParameters)
                     {

--- a/LiveSPICEVst/SimulationProcessor.cs
+++ b/LiveSPICEVst/SimulationProcessor.cs
@@ -53,23 +53,9 @@ namespace LiveSPICEVst
             }
         }
 
-        public int Iterations
-        {
-            get { return iterations; }
-            set
-            {
-                if (iterations != value)
-                {
-                    iterations = value;
-
-                    needRebuild = true;
-                }
-            }
-        }
 
         double sampleRate;
         int oversample = 2;
-        int iterations = 8;
 
         Circuit.Circuit circuit = null;
         Simulation simulation = null;
@@ -308,7 +294,6 @@ namespace LiveSPICEVst
                                         simulation = new Simulation(ts)
                                         {
                                             Oversample = oversample,
-                                            Iterations = iterations,
                                             Input = new[] { inputExpression },
                                             Output = new[] { outputExpression }
                                         };

--- a/LiveSPICEVst/VstProgramParameters.cs
+++ b/LiveSPICEVst/VstProgramParameters.cs
@@ -9,13 +9,11 @@ namespace LiveSPICEVst
     {
         public string SchematicPath { get; set; }
         public int OverSample { get; set; }
-        public int Iterations { get; set; }
         public List<VSTProgramControlParameter> ControlParameters { get; set; }
 
         public VstProgramParameters()
         {
             OverSample = 2;
-            Iterations = 8;
 
             ControlParameters = new List<VSTProgramControlParameter>();
         }

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -18,25 +18,24 @@ namespace Tests
                                                     .WithArgument<string>("pattern", "Glob pattern for files to test")
                                                     .WithOption<bool>(new[] { "--plot" }, "Plot results")
                                                     .WithOption(new[] { "--samples" }, () => 4800, "Samples")
-                                                    .WithHandler(CommandHandler.Create<string, bool, int, int, int, int>(Test)))
+                                                    .WithHandler(CommandHandler.Create<string, bool, int, int, int>(Test)))
                                                .WithCommand("benchmark", "Run benchmarks", c => c
                                                     .WithArgument<string>("pattern", "Glob pattern for files to benchmark")
-                                                    .WithHandler(CommandHandler.Create<string, int, int, int>(Benchmark)))
+                                                    .WithHandler(CommandHandler.Create<string, int, int>(Benchmark)))
                                                .WithGlobalOption(new Option<int>("--sampleRate", () => 48000, "Sample Rate"))
-                                               .WithGlobalOption(new Option<int>("--oversample", () => 8, "Oversample"))
-                                               .WithGlobalOption(new Option<int>("--iterations", () => 8, "Iterations"));
+                                               .WithGlobalOption(new Option<int>("--oversample", () => 4, "Oversample"));
 
             return await rootCommand.InvokeAsync(args);
         }
 
-        public static void Test(string pattern, bool plot, int sampleRate, int samples, int oversample, int iterations)
+        public static void Test(string pattern, bool plot, int sampleRate, int samples, int oversample)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Info };
             var tester = new Test();
 
             foreach (var circuit in GetCircuits(pattern, log))
             {
-                var outputs = tester.Run(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, samples, oversample, iterations);
+                var outputs = tester.Run(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, samples, oversample);
                 if (plot)
                 {
                     tester.PlotAll(circuit.Name, outputs);
@@ -44,7 +43,7 @@ namespace Tests
             }
         }
 
-        public static void Benchmark(string pattern, int sampleRate, int oversample, int iterations)
+        public static void Benchmark(string pattern, int sampleRate, int oversample)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Error };
             var tester = new Test();
@@ -52,7 +51,7 @@ namespace Tests
             System.Console.WriteLine(fmt, "Circuit", "Analysis (ms)", "Solve (ms)", "Sim (kHz)", "Realtime x");
             foreach (var circuit in GetCircuits(pattern, log))
             {
-                double[] result = tester.Benchmark(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, oversample, iterations, log: log);
+                double[] result = tester.Benchmark(circuit, t => Harmonics(t, 0.5, 820, 2), sampleRate, oversample, log: log);
                 double analyzeTime = result[0];
                 double solveTime = result[1];
                 double simRate = result[2];

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -39,7 +39,6 @@ namespace Tests
             int SampleRate,
             int Samples,
             int Oversample,
-            int Iterations,
             Expression? Input = null,
             IEnumerable<Expression>? Outputs = null)
         {
@@ -62,7 +61,6 @@ namespace Tests
             Simulation S = new Simulation(TS)
             {
                 Oversample = Oversample,
-                Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
             };
@@ -104,7 +102,6 @@ namespace Tests
             Func<double, double> Vin,
             int SampleRate,
             int Oversample,
-            int Iterations,
             Expression? Input = null,
             IEnumerable<Expression>? Outputs = null,
             ILog? log = null)
@@ -131,7 +128,6 @@ namespace Tests
             Simulation S = new Simulation(TS)
             {
                 Oversample = Oversample,
-                Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
             };


### PR DESCRIPTION
As @Federerer mentioned on #193, the iterations parameter is of questionable utility. I did some experiments and found that performance was actually *better* with more iterations in some cases. I think this is because the simulation state is closer to converged for the next sample if we don't stop iterating too early. 

I also reduced the default oversample parameter from 8 to 2. I read somewhere ages ago (I can't remember where) that simulating audio circuits needed a high oversampling factor to avoid aliasing harmonics in an audible way, and the author recommended 8x. But, I've never once been able to notice a difference with any oversampling factor in terms of audio quality. Maybe this not an issue because our numerical integration is higher quality or something. We're also just doing a box downsample at the end anyways, perhaps this is negating any advantage from oversampling. 2 is what the VST plugin has been doing all along, and I don't think that has caused any issues. Most people are probably using the VST plugin anyways.

Opening this PR for discussion, more testing is probably needed.