### PR TITLE
Make panning behave similarly to other programs

### DIFF
--- a/LiveSPICE/Controls/SchematicViewer.xaml.cs
+++ b/LiveSPICE/Controls/SchematicViewer.xaml.cs
@@ -148,8 +148,8 @@ namespace LiveSPICE
                 if (mouse_scroll.HasValue)
                 {
                     Vector dx = x - mouse_scroll.Value;
-                    scroll.ScrollToHorizontalOffset(scroll.HorizontalOffset + dx.X * Zoom);
-                    scroll.ScrollToVerticalOffset(scroll.VerticalOffset + dx.Y * Zoom);
+                    scroll.ScrollToHorizontalOffset(scroll.HorizontalOffset - dx.X);
+                    scroll.ScrollToVerticalOffset(scroll.VerticalOffset - dx.Y);
                 }
                 mouse_scroll = x;
                 e.Handled = true;


### PR DESCRIPTION
I made the panning more similar to other programs, which is more like dragging on a touchscreen. So it's inverted, and doesn't change speed depending on how much you're zoomed in.