### PR TITLE
Add Reload button to LiveSPICE VST

### DIFF
--- a/LiveSPICEVst/EditorView.xaml
+++ b/LiveSPICEVst/EditorView.xaml
@@ -12,32 +12,37 @@
         <local:PluginBorder />
         <local:SchematicDisplay x:Name="OverlaySchematic" Opacity="0.5" IsHitTestVisible="False" />
         <DockPanel Margin="8,6">
-            <DockPanel DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="5">
-                <Button DockPanel.Dock="Right" x:Name="ShowAboutButton" Click="ShowAboutButton_Click" HorizontalAlignment="Right">
-                    <TextBlock Margin="5,0,5,0">About</TextBlock>
-                </Button>
-                <Button DockPanel.Dock="Right" x:Name="ShowCircuitButton" Click="ShowCircuitButton_Click" HorizontalAlignment="Right">
-                    <TextBlock Margin="5,0,5,0">View</TextBlock>
-                </Button>
-                <Button x:Name="LoadCircuitButton" Click="LoadCircuitButton_Click" MaxWidth="200">
+			<DockPanel DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="5">
+				<Button x:Name="LoadCircuitButton" Click="LoadCircuitButton_Click">
                     <TextBlock TextTrimming="CharacterEllipsis">Load Schematic</TextBlock>
                 </Button>
-            </DockPanel>
-            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5" UseLayoutRounding="True">
+			</DockPanel>
+			<UniformGrid DockPanel.Dock="Top" Columns="3" Margin="5,0">
+				<Button x:Name="ReloadCircuitButton" Click="ReloadCircuitButton_Click">
+					<TextBlock Margin="5,0,5,0">Reload</TextBlock>
+				</Button>
+				<Button x:Name="ShowCircuitButton" Click="ShowCircuitButton_Click">
+					<TextBlock Margin="5,0,5,0">View</TextBlock>
+				</Button>
+				<Button x:Name="ShowAboutButton" Click="ShowAboutButton_Click">
+					<TextBlock Margin="5,0,5,0">About</TextBlock>
+				</Button>
+			</UniformGrid>
+			<StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5" UseLayoutRounding="True">
                 <StackPanel.Resources>
                     <Style TargetType="{x:Type TextBlock}">
                         <Setter Property="FontWeight" Value="Bold" />
                         <Setter Property="Margin" Value="10,0,5,0"/>
                     </Style>
                 </StackPanel.Resources>
-                <TextBlock>Oversample:</TextBlock>
+                <TextBlock VerticalAlignment="Center">Oversample:</TextBlock>
                 <ComboBox x:Name="OversampleComboBox" SelectionChanged="OversampleComboBox_SelectionChanged">
                     <ComboBoxItem>1</ComboBoxItem>
                     <ComboBoxItem>2</ComboBoxItem>
                     <ComboBoxItem>4</ComboBoxItem>
                     <ComboBoxItem>8</ComboBoxItem>
                 </ComboBox>
-                <TextBlock>Iterations:</TextBlock>
+				<TextBlock VerticalAlignment="Center">Iterations:</TextBlock>
                 <ComboBox x:Name="IterationsComboBox" SelectionChanged="IterationsComboBox_SelectionChanged">
                     <ComboBoxItem>1</ComboBoxItem>
                     <ComboBoxItem>2</ComboBoxItem>

--- a/LiveSPICEVst/EditorView.xaml
+++ b/LiveSPICEVst/EditorView.xaml
@@ -12,23 +12,23 @@
         <local:PluginBorder />
         <local:SchematicDisplay x:Name="OverlaySchematic" Opacity="0.5" IsHitTestVisible="False" />
         <DockPanel Margin="8,6">
-			<DockPanel DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="5">
-				<Button x:Name="LoadCircuitButton" Click="LoadCircuitButton_Click">
+            <DockPanel DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="5">
+                <Button x:Name="LoadCircuitButton" Click="LoadCircuitButton_Click">
                     <TextBlock TextTrimming="CharacterEllipsis">Load Schematic</TextBlock>
                 </Button>
-			</DockPanel>
-			<UniformGrid DockPanel.Dock="Top" Columns="3" Margin="5,0">
-				<Button x:Name="ReloadCircuitButton" Click="ReloadCircuitButton_Click">
-					<TextBlock Margin="5,0,5,0">Reload</TextBlock>
-				</Button>
-				<Button x:Name="ShowCircuitButton" Click="ShowCircuitButton_Click">
-					<TextBlock Margin="5,0,5,0">View</TextBlock>
-				</Button>
-				<Button x:Name="ShowAboutButton" Click="ShowAboutButton_Click">
-					<TextBlock Margin="5,0,5,0">About</TextBlock>
-				</Button>
-			</UniformGrid>
-			<StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5" UseLayoutRounding="True">
+            </DockPanel>
+            <UniformGrid DockPanel.Dock="Top" Columns="3" Margin="5,0">
+                <Button x:Name="ReloadCircuitButton" Click="ReloadCircuitButton_Click">
+                    <TextBlock Margin="5,0,5,0">Reload</TextBlock>
+                </Button>
+                <Button x:Name="ShowCircuitButton" Click="ShowCircuitButton_Click">
+                    <TextBlock Margin="5,0,5,0">View</TextBlock>
+                </Button>
+                <Button x:Name="ShowAboutButton" Click="ShowAboutButton_Click">
+                    <TextBlock Margin="5,0,5,0">About</TextBlock>
+                </Button>
+            </UniformGrid>
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5" UseLayoutRounding="True">
                 <StackPanel.Resources>
                     <Style TargetType="{x:Type TextBlock}">
                         <Setter Property="FontWeight" Value="Bold" />
@@ -42,7 +42,7 @@
                     <ComboBoxItem>4</ComboBoxItem>
                     <ComboBoxItem>8</ComboBoxItem>
                 </ComboBox>
-				<TextBlock VerticalAlignment="Center">Iterations:</TextBlock>
+                <TextBlock VerticalAlignment="Center">Iterations:</TextBlock>
                 <ComboBox x:Name="IterationsComboBox" SelectionChanged="IterationsComboBox_SelectionChanged">
                     <ComboBoxItem>1</ComboBoxItem>
                     <ComboBoxItem>2</ComboBoxItem>

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
 namespace LiveSPICEVst
 {
@@ -95,9 +96,22 @@ namespace LiveSPICEVst
         {
             About about = new About() { Owner = Window.GetWindow(this) };
             about.ShowDialog();
-        }
+		}
 
-        private void ShowCircuitButton_Click(object sender, RoutedEventArgs e)
+		private void ReloadCircuitButton_Click(object sender, RoutedEventArgs e)
+		{
+            if (string.IsNullOrEmpty(Plugin.SchematicPath))
+            {
+                return;
+            }
+
+			Plugin.LoadSchematic(Plugin.SchematicPath);
+
+			UpdateSchematic();
+		}
+
+
+		private void ShowCircuitButton_Click(object sender, RoutedEventArgs e)
         {
             if (Plugin.SimulationProcessor.Schematic != null)
             {

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
 namespace LiveSPICEVst
 {
@@ -96,22 +95,22 @@ namespace LiveSPICEVst
         {
             About about = new About() { Owner = Window.GetWindow(this) };
             about.ShowDialog();
-		}
+        }
 
-		private void ReloadCircuitButton_Click(object sender, RoutedEventArgs e)
-		{
+        private void ReloadCircuitButton_Click(object sender, RoutedEventArgs e)
+        {
             if (string.IsNullOrEmpty(Plugin.SchematicPath))
             {
                 return;
             }
 
-			Plugin.LoadSchematic(Plugin.SchematicPath);
+            Plugin.LoadSchematic(Plugin.SchematicPath);
 
-			UpdateSchematic();
-		}
+            UpdateSchematic();
+        }
 
 
-		private void ShowCircuitButton_Click(object sender, RoutedEventArgs e)
+        private void ShowCircuitButton_Click(object sender, RoutedEventArgs e)
         {
             if (Plugin.SimulationProcessor.Schematic != null)
             {


### PR DESCRIPTION
Hello!

I've recently tried LiveSPICE and I find it very cool and very useful. After playing around with some simulations using the VST plugin inside Cockos REAPER, I found myself constantly having to click the `Load Schematic` button, search for the schematic file and then open it manually after doing some changes to the circuit.

Therefore, this pull request adds a `Reload` button to the VST, which I think is a much more convenient option to have, instead of manually reloading the schematic file every single time you update the circuit. Additionally, since adding a fourth button made everything look a bit squashed, I did a minor layout update, which you can see on the following image:

![LiveSPICE VST GUI Update](https://github.com/dsharlet/LiveSPICE/assets/33221623/34a5099c-9171-492d-b22d-bab8564d73c2)

Please let me know if you have any comments and/or suggestions about this.