### PR TITLE
Remove oversample and iterations from simulation

### DIFF
--- a/LiveSPICE/LiveSimulation.xaml
+++ b/LiveSPICE/LiveSimulation.xaml
@@ -78,24 +78,7 @@
 
         <!-- Toolbars -->
         <ToolBarTray Grid.Row="2">
-            <ToolBar Band="1" BandIndex="1">
-                <TextBlock Text="Oversample:" Margin="5, 0, 2, 0" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                <ComboBox Width="40" IsEditable="True" Text="{Binding Oversample, UpdateSourceTrigger=PropertyChanged, Delay=1000}">
-                    <ComboBoxItem>1</ComboBoxItem>
-                    <ComboBoxItem>2</ComboBoxItem>
-                    <ComboBoxItem>3</ComboBoxItem>
-                    <ComboBoxItem>4</ComboBoxItem>
-                    <ComboBoxItem>6</ComboBoxItem>
-                    <ComboBoxItem>8</ComboBoxItem>
-                    <ComboBoxItem>12</ComboBoxItem>
-                    <ComboBoxItem>16</ComboBoxItem>
-                </ComboBox>
-
-                <TextBlock Text="Iterations:" Margin="5, 0, 2, 0" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                <xctk:IntegerUpDown Value="{Binding Iterations, Delay=1000}" Minimum="1" Maximum="64" />
-
-                <Separator />
-                
+            <ToolBar Band="1" BandIndex="1">                
                 <ls:ImageButton CommandImage="{x:Static ls:Commands.Simulate}" ImageHeight="16" />
             </ToolBar>
             <!-- View -->

--- a/LiveSPICE/LiveSimulation.xaml.cs
+++ b/LiveSPICE/LiveSimulation.xaml.cs
@@ -27,26 +27,6 @@ namespace LiveSPICE
         public Log Log { get { return (Log)log.Content; } }
         public Scope Scope { get { return (Scope)scope.Content; } }
 
-        protected int oversample = 8;
-        /// <summary>
-        /// Simulation oversampling rate.
-        /// </summary>
-        public int Oversample
-        {
-            get { return oversample; }
-            set { oversample = Math.Max(1, value); RebuildSolution(); NotifyChanged(nameof(Oversample)); }
-        }
-
-        protected int iterations = 8;
-        /// <summary>
-        /// Max iterations for numerical algorithms.
-        /// </summary>
-        public int Iterations
-        {
-            get { return iterations; }
-            set { iterations = Math.Max(1, value); RebuildSolution(); NotifyChanged(nameof(Iterations)); }
-        }
-
         private double inputGain = 1.0;
         /// <summary>
         /// Overall input gain.
@@ -295,7 +275,7 @@ namespace LiveSPICE
                 {
                     try
                     {
-                        ComputerAlgebra.Expression h = (ComputerAlgebra.Expression)1 / (stream.SampleRate * Oversample);
+                        ComputerAlgebra.Expression h = (ComputerAlgebra.Expression)1 / stream.SampleRate;
                         TransientSolution solution = Circuit.TransientSolution.Solve(circuit.Analyze(), h, Log);
 
                         simulation = new Simulation(solution)
@@ -303,8 +283,6 @@ namespace LiveSPICE
                             Log = Log,
                             Input = inputs.Keys.ToArray(),
                             Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
-                            Oversample = Oversample,
-                            Iterations = Iterations,
                         };
                     }
                     catch (Exception Ex)
@@ -323,7 +301,7 @@ namespace LiveSPICE
             int id = Interlocked.Increment(ref update);
             new Task(() =>
             {
-                ComputerAlgebra.Expression h = (ComputerAlgebra.Expression)1 / (stream.SampleRate * Oversample);
+                ComputerAlgebra.Expression h = (ComputerAlgebra.Expression)1 / stream.SampleRate;
                 TransientSolution s = Circuit.TransientSolution.Solve(circuit.Analyze(), h, Rebuild ? (ILog)Log : new NullLog());
                 lock (sync)
                 {
@@ -336,8 +314,6 @@ namespace LiveSPICE
                                 Log = Log,
                                 Input = inputs.Keys.ToArray(),
                                 Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
-                                Oversample = Oversample,
-                                Iterations = Iterations,
                             };
                         }
                         else

--- a/LiveSPICEVst/EditorView.xaml
+++ b/LiveSPICEVst/EditorView.xaml
@@ -35,23 +35,6 @@
                         <Setter Property="Margin" Value="10,0,5,0"/>
                     </Style>
                 </StackPanel.Resources>
-                <TextBlock VerticalAlignment="Center">Oversample:</TextBlock>
-                <ComboBox x:Name="OversampleComboBox" SelectionChanged="OversampleComboBox_SelectionChanged">
-                    <ComboBoxItem>1</ComboBoxItem>
-                    <ComboBoxItem>2</ComboBoxItem>
-                    <ComboBoxItem>4</ComboBoxItem>
-                    <ComboBoxItem>8</ComboBoxItem>
-                </ComboBox>
-                <TextBlock VerticalAlignment="Center">Iterations:</TextBlock>
-                <ComboBox x:Name="IterationsComboBox" SelectionChanged="IterationsComboBox_SelectionChanged">
-                    <ComboBoxItem>1</ComboBoxItem>
-                    <ComboBoxItem>2</ComboBoxItem>
-                    <ComboBoxItem>4</ComboBoxItem>
-                    <ComboBoxItem>8</ComboBoxItem>
-                    <ComboBoxItem>16</ComboBoxItem>
-                    <ComboBoxItem>32</ComboBoxItem>
-                    <ComboBoxItem>64</ComboBoxItem>
-                </ComboBox>
             </StackPanel>
             <local:SimulationInterface DataContext="{Binding SimulationProcessor}" />
         </DockPanel>

--- a/LiveSPICEVst/EditorView.xaml.cs
+++ b/LiveSPICEVst/EditorView.xaml.cs
@@ -35,40 +35,6 @@ namespace LiveSPICEVst
             (LoadCircuitButton.Content as TextBlock).Text = (Plugin.SimulationProcessor.Schematic != null) ? Plugin.SimulationProcessor.SchematicName : "Load Schematic";
 
             schematicWindow = null;
-
-            for (int i = 0; i < OversampleComboBox.Items.Count; i++)
-            {
-                if (int.Parse((OversampleComboBox.Items[i] as ComboBoxItem).Content as string) == Plugin.SimulationProcessor.Oversample)
-                {
-                    OversampleComboBox.SelectedIndex = i;
-
-                    break;
-                }
-            }
-
-            for (int i = 0; i < IterationsComboBox.Items.Count; i++)
-            {
-                if (int.Parse((IterationsComboBox.Items[i] as ComboBoxItem).Content as string) == Plugin.SimulationProcessor.Iterations)
-                {
-                    IterationsComboBox.SelectedIndex = i;
-
-                    break;
-                }
-            }
-        }
-
-        private void OversampleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            ComboBox combo = sender as ComboBox;
-
-            Plugin.SimulationProcessor.Oversample = int.Parse((combo.SelectedItem as ComboBoxItem).Content as string);
-        }
-
-        private void IterationsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            ComboBox combo = sender as ComboBox;
-
-            Plugin.SimulationProcessor.Iterations = int.Parse((combo.SelectedItem as ComboBoxItem).Content as string);
         }
 
         private void LoadCircuitButton_Click(object sender, RoutedEventArgs e)

--- a/LiveSPICEVst/LiveSPICEPlugin.cs
+++ b/LiveSPICEVst/LiveSPICEPlugin.cs
@@ -82,8 +82,6 @@ namespace LiveSPICEVst
             VstProgramParameters programParameters = new VstProgramParameters
             {
                 SchematicPath = SimulationProcessor.SchematicPath,
-                OverSample = SimulationProcessor.Oversample,
-                Iterations = SimulationProcessor.Iterations
             };
 
             foreach (var wrapper in SimulationProcessor.InteractiveComponents)
@@ -140,9 +138,6 @@ namespace LiveSPICEVst
                     {
                         LoadSchematic(programParameters.SchematicPath);
                     }
-
-                    SimulationProcessor.Oversample = programParameters.OverSample;
-                    SimulationProcessor.Iterations = programParameters.Iterations;
 
                     foreach (VSTProgramControlParameter controlParameter in programParameters.ControlParameters)
                     {

--- a/LiveSPICEVst/SimulationProcessor.cs
+++ b/LiveSPICEVst/SimulationProcessor.cs
@@ -39,37 +39,7 @@ namespace LiveSPICEVst
             }
         }
 
-        public int Oversample
-        {
-            get { return oversample; }
-            set
-            {
-                if (oversample != value)
-                {
-                    oversample = value;
-
-                    needRebuild = true;
-                }
-            }
-        }
-
-        public int Iterations
-        {
-            get { return iterations; }
-            set
-            {
-                if (iterations != value)
-                {
-                    iterations = value;
-
-                    needRebuild = true;
-                }
-            }
-        }
-
         double sampleRate;
-        int oversample = 2;
-        int iterations = 8;
 
         Circuit.Circuit circuit = null;
         Simulation simulation = null;
@@ -273,7 +243,7 @@ namespace LiveSPICEVst
                 try
                 {
                     Analysis analysis = circuit.Analyze();
-                    TransientSolution ts = TransientSolution.Solve(analysis, (Real)1 / (sampleRate * oversample));
+                    TransientSolution ts = TransientSolution.Solve(analysis, (Real)1 / sampleRate);
 
                     lock (sync)
                     {
@@ -307,8 +277,6 @@ namespace LiveSPICEVst
                                     {
                                         simulation = new Simulation(ts)
                                         {
-                                            Oversample = oversample,
-                                            Iterations = iterations,
                                             Input = new[] { inputExpression },
                                             Output = new[] { outputExpression }
                                         };

--- a/LiveSPICEVst/VstProgramParameters.cs
+++ b/LiveSPICEVst/VstProgramParameters.cs
@@ -8,15 +8,14 @@ namespace LiveSPICEVst
     public class VstProgramParameters
     {
         public string SchematicPath { get; set; }
+        public List<VSTProgramControlParameter> ControlParameters { get; set; }
+
+        // Deprecated, but kept to avoid breaking serialization of state...?
         public int OverSample { get; set; }
         public int Iterations { get; set; }
-        public List<VSTProgramControlParameter> ControlParameters { get; set; }
 
         public VstProgramParameters()
         {
-            OverSample = 2;
-            Iterations = 8;
-
             ControlParameters = new List<VSTProgramControlParameter>();
         }
     }

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -18,25 +18,23 @@ namespace Tests
                                                     .WithArgument<string>("pattern", "Glob pattern for files to test")
                                                     .WithOption<bool>(new[] { "--plot" }, "Plot results")
                                                     .WithOption(new[] { "--samples" }, () => 4800, "Samples")
-                                                    .WithHandler(CommandHandler.Create<string, bool, int, int, int, int>(Test)))
+                                                    .WithHandler(CommandHandler.Create<string, bool, int, int>(Test)))
                                                .WithCommand("benchmark", "Run benchmarks", c => c
                                                     .WithArgument<string>("pattern", "Glob pattern for files to benchmark")
-                                                    .WithHandler(CommandHandler.Create<string, int, int, int>(Benchmark)))
-                                               .WithGlobalOption(new Option<int>("--sampleRate", () => 48000, "Sample Rate"))
-                                               .WithGlobalOption(new Option<int>("--oversample", () => 8, "Oversample"))
-                                               .WithGlobalOption(new Option<int>("--iterations", () => 8, "Iterations"));
+                                                    .WithHandler(CommandHandler.Create<string, int>(Benchmark)))
+                                               .WithGlobalOption(new Option<int>("--sampleRate", () => 48000, "Sample Rate"));
 
             return await rootCommand.InvokeAsync(args);
         }
 
-        public static void Test(string pattern, bool plot, int sampleRate, int samples, int oversample, int iterations)
+        public static void Test(string pattern, bool plot, int sampleRate, int samples)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Info };
             var tester = new Test();
 
             foreach (var circuit in GetCircuits(pattern, log))
             {
-                var outputs = tester.Run(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, samples, oversample, iterations);
+                var outputs = tester.Run(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, samples);
                 if (plot)
                 {
                     tester.PlotAll(circuit.Name, outputs);
@@ -44,7 +42,7 @@ namespace Tests
             }
         }
 
-        public static void Benchmark(string pattern, int sampleRate, int oversample, int iterations)
+        public static void Benchmark(string pattern, int sampleRate)
         {
             var log = new ConsoleLog() { Verbosity = MessageType.Error };
             var tester = new Test();
@@ -52,7 +50,7 @@ namespace Tests
             System.Console.WriteLine(fmt, "Circuit", "Analysis (ms)", "Solve (ms)", "Sim (kHz)", "Realtime x");
             foreach (var circuit in GetCircuits(pattern, log))
             {
-                double[] result = tester.Benchmark(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, oversample, iterations, log: log);
+                double[] result = tester.Benchmark(circuit, t => Harmonics(t, 0.5, 82, 2), sampleRate, log: log);
                 double analyzeTime = result[0];
                 double solveTime = result[1];
                 double simRate = result[2];

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -38,13 +38,11 @@ namespace Tests
             Func<double, double> Vin,
             int SampleRate,
             int Samples,
-            int Oversample,
-            int Iterations,
             Expression? Input = null,
             IEnumerable<Expression>? Outputs = null)
         {
             Analysis analysis = C.Analyze();
-            TransientSolution TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample));
+            TransientSolution TS = TransientSolution.Solve(analysis, (Real)1 / SampleRate);
 
             // By default, pass Vin to each input of the circuit.
             if (Input == null)
@@ -61,8 +59,6 @@ namespace Tests
 
             Simulation S = new Simulation(TS)
             {
-                Oversample = Oversample,
-                Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
             };
@@ -103,8 +99,6 @@ namespace Tests
             Circuit.Circuit C,
             Func<double, double> Vin,
             int SampleRate,
-            int Oversample,
-            int Iterations,
             Expression? Input = null,
             IEnumerable<Expression>? Outputs = null,
             ILog? log = null)
@@ -113,7 +107,7 @@ namespace Tests
             double analyzeTime = Benchmark(1, () => analysis = C.Analyze());
 
             TransientSolution? TS = null;
-            double solveTime = Benchmark(1, () => TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample), log));
+            double solveTime = Benchmark(1, () => TS = TransientSolution.Solve(analysis, (Real)1 / SampleRate, log));
 
             // By default, pass Vin to each input of the circuit.
             if (Input == null)
@@ -130,8 +124,6 @@ namespace Tests
 
             Simulation S = new Simulation(TS)
             {
-                Oversample = Oversample,
-                Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
             };


### PR DESCRIPTION
This is basically a redo of #195, but goes even further and removes the oversample parameter completely. This simplifies the simulation code a bit.

The filtering it does after oversampling is basically just a box filter anyways, which may explain why this has little benefit. Maybe a higher quality filter would make oversampling more useful. But if that's the case and explains why this doesn't matter much, then this won't be a regression vs. the last ~10 years of LiveSPICE :)
