### PR TITLE
Major speedup to simulations

### DIFF
--- a/Circuit/Simulation/TransientSolution.cs
+++ b/Circuit/Simulation/TransientSolution.cs
@@ -195,6 +195,9 @@ namespace Circuit
                 solutions.Count,
                 solutions.Sum(i => i.Unknowns.Count()));
 
+            // Solutions from `Solve` might depend on previous solutions, so we need to make sure to emit the solutions in the order that satisifies such dependencies.
+            solutions.Reverse();
+
             return new TransientSolution(
                 h,
                 solutions,


### PR DESCRIPTION
This change makes the solver much more aggressive about lifting solutions out of the non-linear solver. Previously, we would only search for solutions the order produced by `RowReduce`. Now, we instead repeatedly search for solutions that are independent of any remaining unknowns.

This change is a result of discussion with @andy-cytomic!

The impact to sim speed on example circuits is as follows:

Circuit | master | solver-fix |  
-- | -- | -- | --
59 Bassman Preamp+Tone Stack | 128.4 | 129.1 | 1.005451713
Big Muff Pi | 77.49 | 90.2 | 1.164021164
Boss Super Overdrive SD-1 | 505 | 779.6 | 1.543762376
Bridge Rectifier | 688.6 | 812.4 | 1.179785071
Common Cathode Triode Amplifier | 328.6 | 438.8 | 1.335362142
Common Emitter Transistor Amplifier | 921.2 | 1294 | 1.404689535
Dunlop Cry Baby GCB-95 | 180.6 | 308.1 | 1.705980066
Fender 5e3 | 33.67 | 41.96 | 1.246213246
Ibanez Tube Screamer TS-9 | 837.8 | 1285 | 1.533778945
Marshall Blues Breaker | 351.6 | 521.3 | 1.482650739
Marshall JCM2000 DSL Preamp | 47.72 | 59.91 | 1.255448449
Marshall JCM800 2203 preamp modded | 46.42 | 59.13 | 1.273804395
Marshall JCM800 2203 Preamp | 50.25 | 61.24 | 1.218706468
MXR Distortion + | 438.7 | 522.8 | 1.191702758
MXR Phase 90 | 31.37 | 38.07 | 1.213579853
Op-Amp Model | 681.4 | 1482 | 2.174933959
Orange Rockerverb 50 Preamp | 44.01 | 52.51 | 1.193137923
Passive 1stOrder Lowpass RC | 3.01E+04 | 3.04E+04 | 1.01E+00
Pro Co Rat | 126.2 | 161.1 | 1.276545166
Wien Bridge Oscillator | 645.3 | 1050 | 1.627150163
