### PR TITLE
Enable dynamic parameters

### DIFF
--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -253,6 +253,95 @@ namespace Circuit
         /// <returns></returns>
         public string AnonymousName() { return context.AnonymousName(); }
 
+        /// <summary>
+        /// Describes a parameter for the circuit.
+        /// </summary>
+        public abstract class Parameter
+        {
+            private Component of;
+            /// <summary>
+            /// Component the parameter affects.
+            /// </summary>
+            public Component Of { get { return of; } }
+
+            private Expression expr;
+            /// <summary>
+            /// Expression for the parameter in the system of equations for this analysis.
+            /// </summary>
+            public Expression Expression { get { return expr; } }
+
+            private string name;
+            /// <summary>
+            /// Name of this parameter.
+            /// </summary>
+            public string Name { get { return name; } }
+
+            /// <summary>
+            /// Expression describing the default value.
+            /// </summary>
+            public abstract Expression Default { get; }
+
+            public Parameter(Component Of, string Name, Expression Expression)
+            {
+                of = Of;
+                name = Name;
+                expr = Expression;
+            }
+        }
+
+        /// <summary>
+        /// Describes a ranged parameter for the circuit.
+        /// </summary>
+        public class RangeParameter : Parameter
+        {
+            private double def, min, max;
+            /// <summary>
+            /// Default value of the parameter.
+            /// </summary>
+            public override Expression Default { get { return def; } }
+            /// <summary>
+            /// Minimum value for the parameter.
+            /// </summary>
+            public double Minimum { get { return min; } }
+            /// <summary>
+            /// Maximum value for the parameter.
+            /// </summary>
+            public double Maximum { get { return max; } }
+
+            private SweepType sweep;
+            /// <summary>
+            /// Sweep type of the parameter.
+            /// </summary>
+            public SweepType Sweep { get { return sweep; } }
+
+            public RangeParameter(Component Of, string Name, Expression Expression, double Default, double Minimum, double Maximum, SweepType Sweep)
+                : base(Of, Name, Expression)
+            {
+                def = Default;
+                min = Minimum;
+                max = Maximum;
+                sweep = Sweep;
+            }
+        }
+
+        private List<Parameter> parameters = new List<Parameter>();
+        /// <summary>
+        /// Enumerates the parameters in this analysis.
+        /// </summary>
+        public IEnumerable<Parameter> Parameters { get { return parameters; } }
+
+        /// <summary>
+        /// Create an expression for a parameter in the current context.
+        /// </summary>
+        /// <param name="Name"></param>
+        /// <returns></returns>
+        public Expression AddParameter(Component Of, string Name, double Default, double Min, double Max, SweepType Sweep)
+        {
+            Expression expr = context.Prefix + Name;
+            parameters.Add(new RangeParameter(Of, Name, expr, Default, Min, Max, Sweep)); 
+            return expr;
+        }
+
         private void AddKcl(Dictionary<Expression, Expression> kcl, Expression V, Expression i)
         {
             if (kcl.TryGetValue(V, out var sumi))

--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -273,7 +273,7 @@ namespace Circuit
             /// <summary>
             /// Expression describing the default value.
             /// </summary>
-            public abstract Expression Default { get; }
+            public abstract double Default { get; }
 
             public Parameter(Component Of, Expression Expression)
             {
@@ -291,7 +291,7 @@ namespace Circuit
             /// <summary>
             /// Default value of the parameter.
             /// </summary>
-            public override Expression Default { get { return def; } }
+            public override double Default { get { return def; } }
             /// <summary>
             /// Minimum value for the parameter.
             /// </summary>

--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -270,21 +270,14 @@ namespace Circuit
             /// </summary>
             public Expression Expression { get { return expr; } }
 
-            private string name;
-            /// <summary>
-            /// Name of this parameter.
-            /// </summary>
-            public string Name { get { return name; } }
-
             /// <summary>
             /// Expression describing the default value.
             /// </summary>
             public abstract Expression Default { get; }
 
-            public Parameter(Component Of, string Name, Expression Expression)
+            public Parameter(Component Of, Expression Expression)
             {
                 of = Of;
-                name = Name;
                 expr = Expression;
             }
         }
@@ -314,8 +307,8 @@ namespace Circuit
             /// </summary>
             public SweepType Sweep { get { return sweep; } }
 
-            public RangeParameter(Component Of, string Name, Expression Expression, double Default, double Minimum, double Maximum, SweepType Sweep)
-                : base(Of, Name, Expression)
+            public RangeParameter(Component Of, Expression Expression, double Default, double Minimum, double Maximum, SweepType Sweep)
+                : base(Of, Expression)
             {
                 def = Default;
                 min = Minimum;
@@ -338,7 +331,7 @@ namespace Circuit
         public Expression AddParameter(Component Of, string Name, double Default, double Min, double Max, SweepType Sweep)
         {
             Expression expr = ComputerAlgebra.Variable.New(context.Prefix + Name);
-            parameters.Add(new RangeParameter(Of, Name, expr, Default, Min, Max, Sweep)); 
+            parameters.Add(new RangeParameter(Of, expr, Default, Min, Max, Sweep)); 
             return expr;
         }
 

--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -256,7 +256,7 @@ namespace Circuit
         /// <summary>
         /// Describes a parameter for the circuit.
         /// </summary>
-        public abstract class Parameter
+        public class Parameter
         {
             private Component of;
             /// <summary>
@@ -270,50 +270,17 @@ namespace Circuit
             /// </summary>
             public Expression Expression { get { return expr; } }
 
+            Func<double> getter;
             /// <summary>
-            /// Expression describing the default value.
+            /// Current value of the parameter.
             /// </summary>
-            public abstract double Default { get; }
+            public double Value { get { return getter(); } }
 
-            public Parameter(Component Of, Expression Expression)
+            public Parameter(Component Of, Expression Expression, Func<double> Getter)
             {
                 of = Of;
                 expr = Expression;
-            }
-        }
-
-        /// <summary>
-        /// Describes a ranged parameter for the circuit.
-        /// </summary>
-        public class RangeParameter : Parameter
-        {
-            private double def, min, max;
-            /// <summary>
-            /// Default value of the parameter.
-            /// </summary>
-            public override double Default { get { return def; } }
-            /// <summary>
-            /// Minimum value for the parameter.
-            /// </summary>
-            public double Minimum { get { return min; } }
-            /// <summary>
-            /// Maximum value for the parameter.
-            /// </summary>
-            public double Maximum { get { return max; } }
-
-            private SweepType sweep;
-            /// <summary>
-            /// Sweep type of the parameter.
-            /// </summary>
-            public SweepType Sweep { get { return sweep; } }
-
-            public RangeParameter(Component Of, Expression Expression, double Default, double Minimum, double Maximum, SweepType Sweep)
-                : base(Of, Expression)
-            {
-                def = Default;
-                min = Minimum;
-                max = Maximum;
-                sweep = Sweep;
+                getter = Getter;
             }
         }
 
@@ -328,10 +295,10 @@ namespace Circuit
         /// </summary>
         /// <param name="Name"></param>
         /// <returns></returns>
-        public Expression AddParameter(Component Of, string Name, double Default, double Min, double Max, SweepType Sweep)
+        public Expression AddParameter(Component Of, string Name, Func<double> Getter)
         {
-            Expression expr = ComputerAlgebra.Variable.New(context.Prefix + Name);
-            parameters.Add(new RangeParameter(Of, expr, Default, Min, Max, Sweep)); 
+            Expression expr = Variable.New(context.Prefix + Name);
+            parameters.Add(new Parameter(Of, expr, Getter)); 
             return expr;
         }
 

--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -238,7 +238,11 @@ namespace Circuit
         /// </summary>
         /// <param name="Eq"></param>
         /// <returns></returns>
-        public Expression AddUnknownEqualTo(Expression Eq) { return AddUnknownEqualTo(AnonymousName(), Eq); }
+        public Expression AddUnknownEqualTo(Expression x) {
+            if (x is Constant) return x;
+            if (x is Call c && c.Target is UnknownFunction) return x;
+            return AddUnknownEqualTo(AnonymousName(), x); 
+        }
 
         /// <summary>
         /// Add initial conditions to the system.

--- a/Circuit/Analysis.cs
+++ b/Circuit/Analysis.cs
@@ -337,7 +337,7 @@ namespace Circuit
         /// <returns></returns>
         public Expression AddParameter(Component Of, string Name, double Default, double Min, double Max, SweepType Sweep)
         {
-            Expression expr = context.Prefix + Name;
+            Expression expr = ComputerAlgebra.Variable.New(context.Prefix + Name);
             parameters.Add(new RangeParameter(Of, Name, expr, Default, Min, Max, Sweep)); 
             return expr;
         }

--- a/Circuit/Component.cs
+++ b/Circuit/Component.cs
@@ -21,7 +21,7 @@ namespace Circuit
     /// <summary>
     /// Interface for components that expose a pot controlled value.
     /// </summary>
-    public interface IPotControl: IGroupableComponent
+    public interface IPotControl : IGroupableComponent
     {
         /// <summary>
         /// The value of the pot.
@@ -32,7 +32,7 @@ namespace Circuit
     /// <summary>
     /// Interface for components that expose a button controlled value.
     /// </summary>
-    public interface IButtonControl: IGroupableComponent
+    public interface IButtonControl : IGroupableComponent
     {
         void Click();
         int Position { get; set; }

--- a/Circuit/Components/Capacitor.cs
+++ b/Circuit/Components/Capacitor.cs
@@ -25,7 +25,7 @@ namespace Circuit
             V = Mna.AddUnknownEqualTo("V" + Name, V);
             // i = C*dV/dt
             Expression i = C * D(V, t);
-            //i = Mna.AddUnknownEqualTo("i" + Name, i);
+            i = Mna.AddUnknownEqualTo("i" + Name, i);
             Mna.AddPassiveComponent(Anode, Cathode, i);
             return i;
         }

--- a/Circuit/Components/Potentiometer.cs
+++ b/Circuit/Components/Potentiometer.cs
@@ -63,7 +63,7 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = Mna.AddParameter(this, Name, Wipe, 1e-6, 1.0 - 1e-6, Sweep);
+            Expression P = Mna.AddParameter(this, Name, Wipe, VariableResistor.SweepMin, VariableResistor.SweepMax, Sweep);
 
             Expression R1 = Resistance * P;
             Expression R2 = Resistance * (1 - P);

--- a/Circuit/Components/Potentiometer.cs
+++ b/Circuit/Components/Potentiometer.cs
@@ -63,7 +63,7 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = Mna.AddParameter(this, Name, Wipe, VariableResistor.SweepMin, VariableResistor.SweepMax, Sweep);
+            Expression P = Mna.AddParameter(this, Name, () => VariableResistor.AdjustWipe(Wipe, Sweep));
 
             Expression R1 = Resistance * P;
             Expression R2 = Resistance * (1 - P);

--- a/Circuit/Components/Potentiometer.cs
+++ b/Circuit/Components/Potentiometer.cs
@@ -63,7 +63,7 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = VariableResistor.AdjustWipe(wipe, sweep);
+            Expression P = Mna.AddParameter(this, Name, Wipe, 1e-6, 1.0 - 1e-6, Sweep);
 
             Expression R1 = Resistance * P;
             Expression R2 = Resistance * (1 - P);

--- a/Circuit/Components/VacuumTubes/Triode.cs
+++ b/Circuit/Components/VacuumTubes/Triode.cs
@@ -146,7 +146,8 @@ namespace Circuit
                     break;
                 case TriodeModel.Koren:
                     Expression E1 = Ln1Exp(Kp * (1.0 / Mu + Vgk * Binary.Power(Kvb + Vpk * Vpk, -0.5))) * Vpk / Kp;
-                    ip = Mna.AddUnknownEqualTo(Call.If(E1 > 0, 2d * (E1 ^ Ex) / Kg, 0));
+                    ip = Call.If(E1 > 0, 2d * (E1 ^ Ex) / Kg, 0);
+                    ip = Mna.AddUnknownEqualTo("Ip", ip);
 
                     var vg = (Real)Vg;
                     var knee = (Real)Kn;
@@ -156,7 +157,8 @@ namespace Circuit
                     var b = (knee - vg) / (2 * knee * rg1);
                     var c = (-a * Binary.Power(vg - knee, 2)) - (b * (vg - knee));
 
-                    ig = Mna.AddUnknownEqualTo(Call.If(Vgk < vg - knee, 0, Call.If(Vgk > vg + knee, (Vgk - vg) / rg1, a * Vgk * Vgk + b * Vgk + c)));
+                    ig = Call.If(Vgk < vg - knee, 0, Call.If(Vgk > vg + knee, (Vgk - vg) / rg1, a * Vgk * Vgk + b * Vgk + c));
+                    ig = Mna.AddUnknownEqualTo("Ig", ig);
                     ik = -(ip + ig);
                     break;
                 case TriodeModel.DempwolfZolzer:

--- a/Circuit/Components/VariableResistor.cs
+++ b/Circuit/Components/VariableResistor.cs
@@ -80,10 +80,13 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = Mna.AddParameter(this, Name, Wipe, 1e-6, 1.0 - 1e-6, Sweep);
+            Expression P = Mna.AddParameter(this, Name, Wipe, SweepMin, SweepMax, Sweep);
 
             Resistor.Analyze(Mna, Name, Anode, Cathode, (Expression)Resistance * P);
         }
+
+        public static readonly double SweepMin = 1e-6;
+        public static readonly double SweepMax = 1.0 - SweepMin;
 
         public static double AdjustWipe(double x, SweepType Sweep)
         {

--- a/Circuit/Components/VariableResistor.cs
+++ b/Circuit/Components/VariableResistor.cs
@@ -80,7 +80,7 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = AdjustWipe(wipe, sweep);
+            Expression P = Mna.AddParameter(this, Name, Wipe, 1e-6, 1.0 - 1e-6, Sweep);
 
             Resistor.Analyze(Mna, Name, Anode, Cathode, (Expression)Resistance * P);
         }

--- a/Circuit/Components/VariableResistor.cs
+++ b/Circuit/Components/VariableResistor.cs
@@ -64,7 +64,7 @@ namespace Circuit
 
         protected double wipe = 0.5;
         [Serialize, Description("Position of the wiper on this variable resistor, between 0 and 1.")]
-        public double Wipe { get { return wipe; } set { wipe = value; NotifyChanged(nameof(Wipe)); } }
+        public double Wipe { get { return wipe; } set { wipe = value; NotifyChanged(nameof(Wipe)); NotifyChanged(nameof(IPotControl.PotValue)); } }
         // IPotControl
         double IPotControl.PotValue { get { return Wipe; } set { Wipe = value; } }
 
@@ -80,13 +80,10 @@ namespace Circuit
 
         public override void Analyze(Analysis Mna)
         {
-            Expression P = Mna.AddParameter(this, Name, Wipe, SweepMin, SweepMax, Sweep);
+            Expression P = Mna.AddParameter(this, Name, () => AdjustWipe(Wipe, Sweep));
 
             Resistor.Analyze(Mna, Name, Anode, Cathode, (Expression)Resistance * P);
         }
-
-        public static readonly double SweepMin = 1e-6;
-        public static readonly double SweepMax = 1.0 - SweepMin;
 
         public static double AdjustWipe(double x, SweepType Sweep)
         {

--- a/Circuit/Components/VoltageSource.cs
+++ b/Circuit/Components/VoltageSource.cs
@@ -26,6 +26,9 @@ namespace Circuit
         {
             // Unknown current.
             Mna.AddPassiveComponent(Anode, Cathode, Mna.AddUnknown("i" + Name));
+
+            V = Mna.AddUnknownEqualTo(V);
+
             // Set the voltage.
             Mna.AddEquation(Anode.V - Cathode.V, V);
         }
@@ -35,7 +38,10 @@ namespace Circuit
             Mna.AddInitialConditions(InitialConditions);
         }
         public static void Analyze(Analysis Mna, Node Anode, Node Cathode, Expression V) { Analyze(Mna, Mna.AnonymousName(), Anode, Cathode, V); }
-        public static void Analyze(Analysis Mna, Node Anode, Node Cathode, Expression V, Arrow InitialConditions) { Analyze(Mna, Mna.AnonymousName(), Anode, Cathode, V, InitialConditions); }
+        public static void Analyze(Analysis Mna, Node Anode, Node Cathode, Expression V, Arrow InitialConditions) 
+        { 
+            Analyze(Mna, Mna.AnonymousName(), Anode, Cathode, V, InitialConditions); 
+        }
 
         public override void Analyze(Analysis Mna) { Analyze(Mna, Name, Anode, Cathode, Voltage); }
 

--- a/Circuit/Simulation/TransientSolution.cs
+++ b/Circuit/Simulation/TransientSolution.cs
@@ -101,6 +101,8 @@ namespace Circuit
                 .Substitute(dy_dt.Select(i => Arrow.New(i, 0)).Append(Arrow.New(t, 0), Arrow.New(T, 0), SinglePoleSwitch.IncludeOpen))
                 // Use the initial conditions from analysis.
                 .Substitute(Analysis.InitialConditions)
+                // Use the default parameter values.
+                .Substitute(Analysis.Parameters.Select(i => Arrow.New(i.Expression, i.Default)))
                 // Evaluate variables at t=0.
                 .OfType<Equal>(), y.Select(j => j.Substitute(t, 0)));
 

--- a/Circuit/Simulation/TransientSolution.cs
+++ b/Circuit/Simulation/TransientSolution.cs
@@ -102,7 +102,7 @@ namespace Circuit
                 // Use the initial conditions from analysis.
                 .Substitute(Analysis.InitialConditions)
                 // Use the default parameter values.
-                .Substitute(Analysis.Parameters.Select(i => Arrow.New(i.Expression, i.Default)))
+                .Substitute(Analysis.Parameters.Select(i => Arrow.New(i.Expression, i.Value)))
                 // Evaluate variables at t=0.
                 .OfType<Equal>(), y.Select(j => j.Substitute(t, 0)));
 

--- a/Circuit/Simulation/TransientSolution.cs
+++ b/Circuit/Simulation/TransientSolution.cs
@@ -154,7 +154,6 @@ namespace Circuit
                 IEnumerable<Arrow> linear = F.Solve();
                 if (linear.Any())
                 {
-                    linear = Factor(linear);
                     solutions.Add(new LinearSolutions(linear));
                     LogExpressions(Log, MessageType.Verbose, "Linear solutions:", linear);
                 }
@@ -177,15 +176,12 @@ namespace Circuit
                     // Find linear solutions for dy. 
                     nonlinear.RowReduce(ly);
                     IEnumerable<Arrow> solved = nonlinear.Solve(ly);
-                    solved = Factor(solved);
 
                     // Initial guess for y[t] = y[t - h].
                     IEnumerable<Arrow> guess = F.Unknowns.Select(i => Arrow.New(i, i.Substitute(t, t - h))).ToList();
-                    guess = Factor(guess);
 
                     // Newton system equations.
                     IEnumerable<LinearCombination> equations = nonlinear.Equations.Buffer();
-                    equations = Factor(equations);
 
                     solutions.Add(new NewtonIteration(solved, equations, nonlinear.Unknowns, guess));
                     LogExpressions(Log, MessageType.Verbose, String.Format("Non-linear Newton's method updates ({0}):", String.Join(", ", nonlinear.Unknowns)), equations.Select(i => Equal.New(i, 0)));
@@ -204,9 +200,6 @@ namespace Circuit
         }
         public static TransientSolution Solve(Analysis Analysis, Expression TimeStep, ILog Log) { return Solve(Analysis, TimeStep, new Arrow[] { }, Log); }
         public static TransientSolution Solve(Analysis Analysis, Expression TimeStep) { return Solve(Analysis, TimeStep, new Arrow[] { }, new NullLog()); }
-
-        private static IEnumerable<Arrow> Factor(IEnumerable<Arrow> x) { return x.Select(i => Arrow.New(i.Left, i.Right.Factor())).Buffer(); }
-        private static IEnumerable<LinearCombination> Factor(IEnumerable<LinearCombination> x) { return x.Select(i => LinearCombination.New(i.Select(j => new KeyValuePair<Expression, Expression>(j.Key, j.Value.Factor())))).Buffer(); }
 
         // Shorthand for df/dx.
         protected static Expression D(Expression f, Expression x) { return Call.D(f, x); }

--- a/LiveSPICE/LiveSimulation.xaml.cs
+++ b/LiveSPICE/LiveSimulation.xaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Printing;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -302,6 +303,19 @@ namespace LiveSPICE
             }
         }
 
+        private Simulation MakeSimulation(TransientSolution solution)
+        {
+            return new Simulation(solution)
+            {
+                Log = Log,
+                Input = inputs.Keys.ToArray(),
+                Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
+                Arguments = namedArguments.Select(i => i.Key).ToArray(),
+                Oversample = Oversample,
+                Iterations = Iterations,
+            };
+        }
+
         private void RebuildSolution()
         {
             lock (sync)
@@ -313,16 +327,7 @@ namespace LiveSPICE
                     {
                         ComputerAlgebra.Expression h = (ComputerAlgebra.Expression)1 / (stream.SampleRate * Oversample);
                         TransientSolution solution = Circuit.TransientSolution.Solve(circuit.Analyze(), h, Log);
-
-                        simulation = new Simulation(solution)
-                        {
-                            Log = Log,
-                            Input = inputs.Keys.ToArray(),
-                            Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
-                            Arguments = namedArguments.Select(i => i.Key).ToArray(),
-                            Oversample = Oversample,
-                            Iterations = Iterations,
-                        };
+                        simulation = MakeSimulation(solution);
                     }
                     catch (Exception Ex)
                     {
@@ -348,15 +353,7 @@ namespace LiveSPICE
                     {
                         if (Rebuild)
                         {
-                            simulation = new Simulation(s)
-                            {
-                                Log = Log,
-                                Input = inputs.Keys.ToArray(),
-                                Output = probes.Select(i => i.V).Concat(OutputChannels.Select(i => i.Signal)).ToArray(),
-                                Arguments = namedArguments.Select(i => i.Key).ToArray(),
-                                Oversample = Oversample,
-                                Iterations = Iterations,
-                            };
+                            simulation = MakeSimulation(s);
                         }
                         else
                         {

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -45,8 +45,6 @@ namespace Tests
         {
             Analysis analysis = C.Analyze();
             TransientSolution TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample));
-            
-            List<KeyValuePair<Expression, double>> arguments = analysis.Parameters.Select(i => new KeyValuePair<Expression, double>(i.Expression, (double)i.Default)).ToList();
 
             // By default, pass Vin to each input of the circuit.
             if (Input == null)
@@ -67,13 +65,13 @@ namespace Tests
                 Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
-                Arguments = arguments.Select(i => i.Key),
+                Arguments = analysis.Parameters.Select(i => i.Expression),
             };
 
             Dictionary<Expression, List<double>> outputs = 
                 S.Output.ToDictionary(i => i, i => new List<double>(Samples));
 
-            List<double> parameters = arguments.Select(i => i.Value).ToList();
+            double[] parameters = analysis.Parameters.Select(i => i.Value).ToArray();
 
             double T = S.TimeStep;
             double t = 0;
@@ -84,7 +82,7 @@ namespace Tests
                 // Using a varying number of samples on each call to S.Run
                 int N = Math.Min(remaining, rng.Next(1000, 10000));
                 double[] inputBuffer = new double[N];
-                List<double[]> outputBuffers = S.Output.Select(i => new double[N]).ToList();
+                double[][] outputBuffers = S.Output.Select(i => new double[N]).ToArray();
                 for (int n = 0; n < N; ++n, t += T)
                     inputBuffer[n] = Vin(t);
 
@@ -120,8 +118,6 @@ namespace Tests
             TransientSolution? TS = null;
             double solveTime = Benchmark(1, () => TS = TransientSolution.Solve(analysis, (Real)1 / (SampleRate * Oversample), log));
 
-            List<KeyValuePair<Expression, double>> arguments = analysis.Parameters.Select(i => new KeyValuePair<Expression, double>(i.Expression, (double)i.Default)).ToList();
-
             // By default, pass Vin to each input of the circuit.
             if (Input == null)
                 Input = FindInput(C);
@@ -141,14 +137,14 @@ namespace Tests
                 Iterations = Iterations,
                 Input = new[] { Input },
                 Output = Outputs,
-                Arguments = arguments.Select(i => i.Key),
+                Arguments = analysis.Parameters.Select(i => i.Expression),
             };
 
             int N = 1000;
             double[] inputBuffer = new double[N];
-            List<double[]> outputBuffers = Outputs.Select(i => new double[N]).ToList();
+            double[][] outputBuffers = Outputs.Select(i => new double[N]).ToArray();
 
-            List<double> parameters = arguments.Select(i => i.Value).ToList();
+            double[] parameters = analysis.Parameters.Select(i => i.Value).ToArray();
             double T = 1.0 / SampleRate;
             double t = 0;
             double runTime = Benchmark(3, () =>


### PR DESCRIPTION
This branch reverts a ~10 year old commit https://github.com/dsharlet/LiveSPICE/commit/238ba018b0f3a4834f82286f9a379ac6db520dfb to make simulation parameters (potentiometers) work the way they should: the circuit is compiled with the potentiometer value as a variable, and then the variable is substituted during simulation. This allows continuously and smoothly varying the parameters!

Unfortunately, that approach struggled a lot with performance and scalability. However, some recent discoveries (thanks to conversations with @andy-cytomic and @Federer's #196) have revived this approach! Currently, there's still a pretty significant hit to performance with this branch, but it's not *terrible*:

Circuit | master | dynamic-parameters |  
-- | -- | -- | --
59 Bassman Preamp+Tone Stack | 129.1 | 82.35 | 0.6378776143
Big Muff Pi | 90.2 | 54.57 | 0.6049889135
Boss Super Overdrive SD-1 | 779.6 | 440.2 | 0.5646485377
Bridge Rectifier | 812.4 | 828.1 | 1.019325455
Common Cathode Triode Amplifier | 438.8 | 426.6 | 0.9721969006
Common Emitter Transistor Amplifier | 1294 | 1261 | 0.9744976816
Dunlop Cry Baby GCB-95 | 308.1 | 119.9 | 0.3891593638
Fender 5e3 | 41.96 | 21.67 | 0.5164442326
Ibanez Tube Screamer TS-9 | 1285 | 552.4 | 0.4298832685
Marshall Blues Breaker | 521.3 | 221 | 0.4239401496
Marshall JCM2000 DSL Preamp | 59.91 | 36.25 | 0.6050742781
Marshall JCM800 2203 preamp modded | 59.13 | 35.93 | 0.6076441739
Marshall JCM800 2203 Preamp | 61.24 | 47.49 | 0.7754735467
MXR Distortion + | 522.8 | 292 | 0.558530987
MXR Phase 90 | 38.07 | 49.92 | 1.311268716
Op-Amp Model | 1482 | 1085 | 0.7321187584

The really key observation was from discussing this with @andy-cytomic, I realized that if we make an intermediate variable for capacitor currents, that avoids the really problematic impact of the parameter variables on the solution. More details on #94. This was literally a one line change that already existed in the code! https://github.com/dsharlet/LiveSPICE/commit/5398a639515c7ab47b4ffc28ec625eef4278f806 This now means we do something more similar to the standard MNA procedure for capacitors.

Still TODO:
- Update the VST plugin (cc @mikeoliphant)
- One of the example circuits is failing on this branch, due to an expression explosion.
- The performance hit is not great. Unfortunately, the optimization in #237 disproportionately benefited master, so the gap between master and this branch is now even bigger than it otherwise would have been.

I am pretty close to thinking that we should just merge this despite the performance regression. Dynamic parameters are a huge win, I think they're worth the performance hit, and I have a clear line of site to ComputerAlgebra improvements that should mitigate the regression. I have ideas for how to improve ComputerAlgebra significantly for this new approach. Unfortunately me from 15 years ago was a bit dumb, so it's harder than it should be to fix it.

Fixes #94
