### PR TITLE
Update VST to latest AudioPlugSharp

### DIFF
--- a/LiveSPICEVst/LiveSPICEPlugin.cs
+++ b/LiveSPICEVst/LiveSPICEPlugin.cs
@@ -22,8 +22,8 @@ namespace LiveSPICEVst
         new public EditorView EditorView { get; set; }
         public string SchematicPath { get { return SimulationProcessor.SchematicPath; } }
 
-        AudioIOPort monoInput;
-        AudioIOPort monoOutput;
+        AudioIOPortManaged monoInput;
+        AudioIOPortManaged monoOutput;
 
         bool haveSimulationError = false;
 
@@ -52,8 +52,8 @@ namespace LiveSPICEVst
         {
             base.Initialize();
 
-            InputPorts = new AudioIOPort[] { monoInput = new AudioIOPort("Mono Input", EAudioChannelConfiguration.Mono, forceCopy: true) };
-            OutputPorts = new AudioIOPort[] { monoOutput = new AudioIOPort("Mono Output", EAudioChannelConfiguration.Mono, forceCopy: true) };
+            InputPorts = new AudioIOPortManaged[] { monoInput = new AudioIOPortManaged("Mono Input", EAudioChannelConfiguration.Mono) };
+            OutputPorts = new AudioIOPortManaged[] { monoOutput = new AudioIOPortManaged("Mono Output", EAudioChannelConfiguration.Mono) };
         }
 
         public override void InitializeProcessing()

--- a/LiveSPICEVst/LiveSPICEVst.csproj
+++ b/LiveSPICEVst/LiveSPICEVst.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>LiveSPICEVst</AssemblyName>
     <Product>LiveSPICEVst</Product>
@@ -24,8 +24,8 @@
     <ProjectReference Include="..\Util\Util.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AudioPlugSharp" Version="0.5.6" />
-    <PackageReference Include="AudioPlugSharpWPF" Version="0.5.6" />
+    <PackageReference Include="AudioPlugSharp" Version="0.6.10" />
+    <PackageReference Include="AudioPlugSharpWPF" Version="0.6.10" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>

--- a/MockVst/MockVst.csproj
+++ b/MockVst/MockVst.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>LiveSPICEApp</AssemblyName>
     <Product>LiveSPICEApp</Product>


### PR DESCRIPTION
This updates the VST to the latest version of AudioPlugSharp. Plugins now run in isolated assembly load contexts so state remains independent when multiple instances of the plugin are loaded at the same time. 

Resolves https://github.com/dsharlet/LiveSPICE/issues/253
Resolves https://github.com/dsharlet/LiveSPICE/issues/244