### PR TITLE
Fix the sign of the op-amp's output resistance

### DIFF
--- a/Circuit/Components/OpAmp.cs
+++ b/Circuit/Components/OpAmp.cs
@@ -73,8 +73,17 @@ namespace Circuit
                 Diode.Analyze(Mna, nee, pp1, 8e-16, 1);
             }
 
-            // Output current is buffered.
-            Mna.AddTerminal(Out, (pp1.V - Out.V) / Rout);
+            // Output current is buffered: a Thevenin source of open-circuit voltage pp1 behind a
+            // series Rout. The buffer rather than the pole node supplies the current, which is why
+            // nothing is added back at pp1.
+            //
+            // AddTerminal adds its current to the node's Kirchhoff sum, and that sum is of currents
+            // *leaving* the node: Resistor.Analyze computes i = (Anode.V - Cathode.V)/R and hands it
+            // to AddPassiveComponent, which adds +i at the anode and -i at the cathode. Capacitor,
+            // Inductor and Diode all define i the same way. A source of voltage pp1 behind Rout
+            // therefore draws (Out - pp1)/Rout out of Out, whichever of the two nodes you care to
+            // call the anode.
+            Mna.AddTerminal(Out, (Out.V - pp1.V) / Rout);
 
             Mna.PopContext();
         }


### PR DESCRIPTION
`Circuit.OpAmp`'s output stage adds its terminal current to the wrong side of the node's Kirchhoff sum, so the stage presents an output resistance of **−Rout** rather than +Rout.

```csharp
// Circuit/Components/OpAmp.cs
Mna.AddTerminal(Out, (pp1.V - Out.V) / Rout);   // present
Mna.AddTerminal(Out, (Out.V - pp1.V) / Rout);   // proposed
```

### Why that is the wrong sign

`Analysis.AddTerminal` adds its current to the node's sum, and that sum is of currents *leaving* the node: `Resistor.Analyze` computes `i = (Anode.V - Cathode.V)/R` and passes it to `AddPassiveComponent`, which adds `+i` at the anode and `-i` at the cathode. `Capacitor`, `Inductor` and `Diode` all define their current the same way. A Thévenin source of open-circuit voltage `pp1` behind a series `Rout` therefore draws `(Out - pp1)/Rout` out of the output node.

This does not depend on which node you call the anode. Label the branch `pp1 → Out` instead and the cathode-side term is `-(pp1 - Out)/Rout`, which is the same expression. The line as it stands is the anode-side contribution applied at the cathode node.

### Why it is hard to notice

With the default `Aol` of 1e6 the feedback swamps a 100 Ω error in the output stage's source impedance, so it is invisible at DC and in any level measurement. What survives is a phase error of about one part in ten thousand at 1 kHz — the closed-loop pole moves by 0.1 per cent — and two things turn that into something you can hear or measure.

**A circuit that clips converts a phase error into a shift in *when* the output flips.** Compared against ngspice-46 on a diode clipper behind an op-amp gain stage, driven at 0.1 V and 1 kHz, both tools fed the identical piecewise-linear source and read back on the same grid:

| | worst \|LiveSPICE − ngspice\| | of peak | ratio when the timestep halves |
|---|---|---|---|
| present | 8.90 × 10⁻² V | 15 % | 1.03 |
| with this change | 1.32 × 10⁻³ V | 0.23 % | **3.95** |

The last column is the part that matters. A difference between two models does not shrink when the timestep halves; a second-order integration rule's truncation error quarters. Before the change the disagreement did not move at all, so it was a model difference. After it, it converges at the rate the rule promises, so what is left is only the integration.

**A negative source impedance is an active element, and it makes a node unstable when nothing else loads it.** A precision rectifier — an op-amp with a diode in its feedback loop — renders at oversample 8 and **diverges at 16 and at 32**, at t = 8 ms, every time. Raising the oversampling is the usual remedy for a hard circuit, and on that one it is what breaks it. When the diode turns off, the op-amp's output node is loaded by nothing else and the −1/Rout term is unmasked. With this change the circuit renders at 8, 16, 32 and 64 with a converging sequence of peaks.

### Confirming what the present line computes, rather than inferring it

Giving ngspice a literal negative output resistor (`Ro buf out -100`) in an otherwise identical macromodel makes it agree with the **unfixed** code to 1.28 × 10⁻³ V at a convergence ratio of 3.97 — the mirror image of the fixed code against +100 Ω, which is 1.32 × 10⁻³ V at 3.95. An independent simulator, told explicitly to use −100 Ω, reproduces the present behaviour.

### Possibly related: #269

In a stage that clips by saturating the op-amp rather than with diodes, the wrong sign shows up directly in the clamped level. With `pp1` pinned by the internal limiter, the output into a load `R` is `pp1·R/(R + Rout)` correctly and `pp1·R/(R − Rout)` as it stands — so the "flat" top is not flat, it rises above the clamp and moves with whatever the load is doing, and it diverges as `R` approaches Rout. A phase error also compounds stage by stage.

That is consistent with #269, "Clean Signal seems present in op-amp circuits", which reports clean signal blended in even in inverting configurations and worsening with more gain stages. I have not reproduced that reporter's circuits, so I am offering it as a lead rather than a diagnosis.

### Scope

This changes the output of every circuit using `Circuit.OpAmp`, so any stored reference numbers will need regenerating. `Circuit.IdealOpAmp` is unaffected. In the test corpus the affected schematics are the two Active 1stOrder RC filters, MXR Distortion +, the three Op-Amp examples, Pro Co Rat and the Wien Bridge Oscillator.

The oscillator is the one worth checking, since it could in principle have been relying on the negative resistance to oscillate. It was not: driven with silence it still oscillates, its limiter-set amplitude moving from 1.168 V to 1.217 V peak. Both legs of `Tests test` pass.

Happy to add a regression test if you would like one — the cleanest is probably an assertion on an open-loop stage's loaded output level, where the output resistance is not hidden by feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
